### PR TITLE
Add support for multiple manifests per yaml file

### DIFF
--- a/pkg/utilities/components/meta/testdata/multiple-manifests-1-initial.yaml
+++ b/pkg/utilities/components/meta/testdata/multiple-manifests-1-initial.yaml
@@ -1,0 +1,7 @@
+# This comment should be preserved
+---
+apiVersion: test/v1
+kind: FirstTestObject
+---
+apiVersion: test/v1
+kind: SecondTestObject

--- a/pkg/utilities/components/meta/testdata/multiple-manifests-2-edited.yaml
+++ b/pkg/utilities/components/meta/testdata/multiple-manifests-2-edited.yaml
@@ -1,0 +1,12 @@
+# Edited comment. The old default one will not be added again as it did not change against the initial.
+---
+# First test object has been removed, added third test object below instead.
+---
+apiVersion: test/v1
+kind: SecondTestObject
+data:
+  edited: "by_user"
+  my: "secret"
+---
+apiVersion: test/v1
+kind: ThirdTestObject # Instead of the first test object

--- a/pkg/utilities/components/meta/testdata/multiple-manifests-3-new-default.yaml
+++ b/pkg/utilities/components/meta/testdata/multiple-manifests-3-new-default.yaml
@@ -1,0 +1,15 @@
+# This comment should be preserved
+---
+apiVersion: test/v1
+kind: FirstTestObject
+data:
+  change_to_first_obj: "ignored_as_removed_by_user"
+---
+apiVersion: test/v1
+kind: SecondTestObject
+data:
+  edited: "true"
+  in: "default"
+---
+apiVersion: test/v1
+kind: FourthTestObject

--- a/pkg/utilities/components/meta/testdata/multiple-manifests-4-expected-generated.yaml
+++ b/pkg/utilities/components/meta/testdata/multiple-manifests-4-expected-generated.yaml
@@ -1,0 +1,16 @@
+# Edited comment. The old default one will not be added again as it did not change against the initial.
+---
+# First test object has been removed, added third test object below instead.
+---
+apiVersion: test/v1
+kind: SecondTestObject
+data:
+  edited: "by_user"
+  in: "default"
+  my: "secret"
+---
+apiVersion: test/v1
+kind: FourthTestObject
+---
+apiVersion: test/v1
+kind: ThirdTestObject # Instead of the first test object


### PR DESCRIPTION
**What this PR does / why we need it**:
For this feature, the file is split by the `---` separator, the individual sections are matched by key, merged and concatenated on write to output again.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add support for multiple manifests per YAML file.
```
