### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,8 @@ jobs:
       contents: read
 
   tests:
+    permissions:
+      contents: read
     runs-on: ${{ github.repository_owner == 'gardener' && 'ubuntu-latest-large' || 'ubuntu-latest' }}
     steps:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/gardener-landscape-kit/security/code-scanning/1](https://github.com/gardener/gardener-landscape-kit/security/code-scanning/1)

In general, this issue is fixed by explicitly setting `permissions` for each job (or at the workflow root) so the GITHUB_TOKEN only has the minimal access required. Here, the `tests` job only checks out code, sets up Go, runs verification, and exports artifacts via an action; none of these needs write access to repository contents. The other jobs already use `permissions: contents: read`, which is a reasonable baseline and matches CodeQL’s suggestion.

The best targeted fix is to add a `permissions` block with `contents: read` to the `tests` job. This keeps behavior unchanged (tests and artifact export still work) while ensuring the job no longer inherits potentially broader repository defaults. Concretely, in `.github/workflows/build.yaml` under `jobs:`, locate the `tests:` job definition (line 23 onward) and insert:

```yaml
    permissions:
      contents: read
```

right after `tests:` (before `runs-on:`), matching the indentation style already used in the `gardener-landscape-kit` job. No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
