### PR TITLE
Enable updates to components.yaml default versions file, also patch updates for release branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,10 @@
     commands: ['make generate'],
     fileFilters: ['.github/**', 'pkg/**', 'docs/**'],
   },
+  baseBranchPatterns: [
+    'main',
+    '/^release-v\\d+\\.\\d+$/',
+  ],
   prFooter: "**Release note**:\n\
 ```other dependency\n\
 The following dependencies have been updated:\n\
@@ -15,7 +19,28 @@ The following dependencies have been updated:\n\
 - `{{upgrade.depName}}` from `{{upgrade.currentVersion}}` to `{{upgrade.newVersion}}`. {{#if (equals upgrade.datasource 'github-releases')}}[Release Notes](https://github.com/{{upgrade.depName}}/releases/tag/{{upgrade.newVersion}}){{/if}}\n\
 {{/each}}\n\
 ```",
+  regexManagers: [
+    {
+      managerFilePatterns: ['/^componentvector/components\\.yaml$/'],
+      matchStrings: [
+        // Match default versions in components.yaml, regardless of the order of the fields.
+        '- (?:(?:name: (?<depName>[^\\s]+)|sourceRepository: https://github\\.com/(?<packageName>[^\\s]+)|version: (?<currentValue>v?[^\\s]+))\\s*\\n?\\s*){3}',
+      ],
+      datasourceTemplate: 'github-releases',
+    },
+  ],
   packageRules: [
+    {
+      matchFileNames: ['!componentvector/components.yaml'],
+      matchBaseBranches: ['/^release-v\\d+\\.\\d+$/'],
+      enabled: false,
+    },
+    {
+      matchFileNames: ['componentvector/components.yaml'],
+      matchBaseBranches: ['/^release-v\\d+\\.\\d+$/'],
+      matchUpdateTypes: ['minor', 'major'],
+      enabled: false,
+    },
     {
       matchDatasources: ['go'],
       groupName: "open-component-model-bindings-go-descriptor-runtime",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Make Renovate detect and update the dependencies in the `components.yaml` file.

Also, make Renovate propose patch updates to those dependencies for release branches

**Which issue(s) this PR fixes**:
Belongs to #51 

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Provide patch updates to the default dependency vector in release branches at componentsvector/components.yaml.
```
