### PR TITLE
Add health checks and reorder Kustomization configs

### DIFF
--- a/pkg/components/gardener-extensions/networking-calico/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/networking-calico/templates/landscape/flux-kustomization.yaml
@@ -4,13 +4,20 @@ metadata:
   name: extension-networking-calico
   namespace: garden
 spec:
-  interval: 30m
-  path: {{ .landscapeComponentPath }}
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: {{ .landscapeComponentPath }}
+  prune: true
   dependsOn:
   - name: gardener-operator
     namespace: garden
+  interval: 30m
+  timeout: 10m
+  retryInterval: 2m
+  wait: true
+  healthCheckExprs:
+  - apiVersion: operator.gardener.cloud/v1alpha1
+    kind: Extension
+    current: "status.conditions.filter(e, e.type == 'Installed').all(e, e.status == 'True')"

--- a/pkg/components/gardener-extensions/networking-cilium/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/networking-cilium/templates/landscape/flux-kustomization.yaml
@@ -4,13 +4,20 @@ metadata:
   name: extension-networking-cilium
   namespace: garden
 spec:
-  interval: 30m
-  path: {{ .landscapeComponentPath }}
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: {{ .landscapeComponentPath }}
+  prune: true
   dependsOn:
   - name: gardener-operator
     namespace: garden
+  interval: 30m
+  timeout: 10m
+  retryInterval: 2m
+  wait: true
+  healthCheckExprs:
+  - apiVersion: operator.gardener.cloud/v1alpha1
+    kind: Extension
+    current: "status.conditions.filter(e, e.type == 'Installed').all(e, e.status == 'True')"

--- a/pkg/components/gardener/garden/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener/garden/templates/landscape/flux-kustomization.yaml
@@ -4,13 +4,22 @@ metadata:
   name: garden
   namespace: garden
 spec:
-  interval: 30m
-  path: {{ .landscapeComponentPath }}
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: {{ .landscapeComponentPath }}
+  prune: true
   dependsOn:
   - name: gardener-operator
     namespace: garden
+  interval: 30m
+  timeout: 10m
+  retryInterval: 2m
+  wait: true
+  healthCheckExprs:
+  - apiVersion: operator.gardener.cloud/v1alpha1
+    kind: Garden
+    inProgress: "status.lastOperation.state == 'Processing'"
+    failed: "status.lastOperation.state != 'Succeeded'"
+    current: "status.conditions.all(c, c.status == 'True')"

--- a/pkg/components/gardener/operator/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener/operator/templates/landscape/flux-kustomization.yaml
@@ -4,10 +4,11 @@ metadata:
   name: gardener-operator
   namespace: garden
 spec:
-  interval: 30m
-  path: {{ .landscapeComponentPath }}
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: {{ .landscapeComponentPath }}
+  prune: true
+  interval: 30m
+  wait: true


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Properly check installation of `Garden` and operator `Extension` resources.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
- The reordering I have performed to have a better order w.r.t. importance and usage.
- `wait: true` awaits readiness of all created resources (ignores `healthChecks:`) ([docs](https://fluxcd.io/flux/components/kustomize/kustomizations/#wait))
- `timeout` and `retryInterval` have been added for better control over `ks` readiness on state reconciliations
- `healthCheckExprs` have been added to check readiness of CRDs.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
