### PR TITLE
Add dummy target `ci-e2e-kind` to prepare for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,17 @@ kind-up: registry-up git-server-up $(KIND) $(KUBECTL) $(HELM)
 kind-down: git-server-down registry-down $(KIND) $(KUBECTL)
 	@$(REPO_ROOT)/dev-setup/kind/kind-delete-cluster.sh single
 
+#########################################
+# E2E Tests                             #
+#########################################
+
 .PHONY: e2e-prepare
 e2e-prepare: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ) $(GLK_PRETTIFY) $(GLK_GLK)
 	@$(REPO_ROOT)/dev-setup/kind/generate-repos.sh
 	@$(REPO_ROOT)/dev-setup/kind/deploy-flux.sh
 	@$(REPO_ROOT)/dev-setup/kind/prepare-garden.sh
 	@$(REPO_ROOT)/dev-setup/kind/build-and-add-provider-local.sh
+
+.PHONY: ci-e2e-kind
+ci-e2e-kind:
+	@echo "Temporary dummy target until e2e tests are implemented."


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
This decouples [the change in the ci-infra repository](https://github.com/gardener/ci-infra/pull/5255) from the [implementation of the e2e tests in this repository](https://github.com/gardener/gardener-landscape-kit/pull/75).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
