### PR TITLE
Fix extraction of `depName` by Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,7 +24,7 @@ The following dependencies have been updated:\n\
       managerFilePatterns: ['/^componentvector/components\\.yaml$/'],
       matchStrings: [
         // Match default versions in components.yaml, regardless of the order of the fields.
-        '- (?:(?:name: (?<depName>[^\\s]+)|sourceRepository: https://github\\.com/(?<packageName>[^\\s]+)|version: (?<currentValue>v?[^\\s]+))\\s*\\n?\\s*){3}',
+        '- (?:(?:name: github\\.com/(?<depName>[^\\s]+)|sourceRepository: https://github\\.com/(?<packageName>[^\\s]+)|version: (?<currentValue>v?[^\\s]+))\\s*\\n?\\s*){3}',
       ],
       datasourceTemplate: 'github-releases',
     },


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Prevent duplicate github.com prefix in release note generation.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
