### PR TITLE
Handle non-cleaned absolute output paths properly

### DIFF
--- a/pkg/components/types.go
+++ b/pkg/components/types.go
@@ -7,6 +7,7 @@ package components
 import (
 	_ "embed"
 	"fmt"
+	"path"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/afero"
@@ -112,7 +113,7 @@ func NewOptions(opts *generateoptions.Options, fs afero.Afero) (Options, error) 
 
 	return &options{
 		componentVector: componentVector,
-		targetPath:      opts.TargetDirPath,
+		targetPath:      path.Clean(opts.TargetDirPath),
 		filesystem:      fs,
 		logger:          opts.Log,
 	}, nil

--- a/pkg/components/types_test.go
+++ b/pkg/components/types_test.go
@@ -53,7 +53,16 @@ var _ = Describe("Types", func() {
 				componentOpts, err := components.NewOptions(opts, fs)
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(componentOpts.GetTargetPath()).To(BeEmpty())
+				Expect(componentOpts.GetTargetPath()).To(Equal("."))
+			})
+
+			It("should return a cleaned path", func() {
+				opts.TargetDirPath = "/path/to/target/../landscape"
+
+				componentOpts, err := components.NewOptions(opts, fs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(componentOpts.GetTargetPath()).To(Equal("/path/to/landscape"))
 			})
 		})
 

--- a/pkg/utils/kustomization/kustomization.go
+++ b/pkg/utils/kustomization/kustomization.go
@@ -65,7 +65,7 @@ func WriteKustomizationComponent(objects map[string][]byte, baseDir, componentDi
 // Kustomize kustomization.yaml files for each level until each component leaf node containing a Flux Kustomization is reached.
 func WriteLandscapeComponentsKustomizations(options components.Options) error {
 	fs := options.GetFilesystem()
-	targetDir := path.Clean(options.GetTargetPath())
+	targetDir := options.GetTargetPath()
 	componentsDir := filepath.Join(targetDir, components.DirName)
 
 	return fs.Walk(componentsDir, writeKustomizationsToFileTree(fs, targetDir))

--- a/pkg/utils/kustomization/kustomization.go
+++ b/pkg/utils/kustomization/kustomization.go
@@ -65,7 +65,7 @@ func WriteKustomizationComponent(objects map[string][]byte, baseDir, componentDi
 // Kustomize kustomization.yaml files for each level until each component leaf node containing a Flux Kustomization is reached.
 func WriteLandscapeComponentsKustomizations(options components.Options) error {
 	fs := options.GetFilesystem()
-	targetDir := options.GetTargetPath()
+	targetDir := path.Clean(options.GetTargetPath())
 	componentsDir := filepath.Join(targetDir, components.DirName)
 
 	return fs.Walk(componentsDir, writeKustomizationsToFileTree(fs, targetDir))

--- a/pkg/utils/kustomization/kustomization_test.go
+++ b/pkg/utils/kustomization/kustomization_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Kustomization", func() {
 				Options: &cmd.Options{
 					Log: logr.Discard(),
 				},
-				TargetDirPath: "/landscapeDir",
+				TargetDirPath: "/absolute/path/with/../to/repo/landscape",
 			}, fs)
 			Expect(err).NotTo(HaveOccurred())
 		})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
When generating into non-cleaned output dirs, the generated `kustomization.yaml`s end up in the wrong place.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Generating the landscape directory now works with non-cleaned paths (e.g., including `../`).
```
