### PR TITLE
Keep YAML node style as-is in current

### DIFF
--- a/pkg/utils/meta/diff.go
+++ b/pkg/utils/meta/diff.go
@@ -143,10 +143,10 @@ func threeWayMerge(oldDefault, newDefault, current *yaml.Node) *yaml.Node {
 	currentMap := buildMap(current)
 	newMap := buildMap(newDefault)
 
-	// Create result node preserving current's comments
+	// Create result node preserving current's comments and style
 	result := &yaml.Node{
 		Kind:        yaml.MappingNode,
-		Style:       newDefault.Style,
+		Style:       current.Style,
 		Tag:         newDefault.Tag,
 		HeadComment: current.HeadComment,
 		LineComment: current.LineComment,

--- a/pkg/utils/meta/diff_test.go
+++ b/pkg/utils/meta/diff_test.go
@@ -160,5 +160,37 @@ var _ = Describe("Meta Dir Config Diff", func() {
 			_, err = meta.ThreeWayMergeManifest(emptyYaml, emptyYaml, emptyYaml)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		Describe("retain a completely replaced manifest content in a glk-managed file", func() {
+			It("should keep the data section expanded", func() {
+				oldDefault, err := testdata.ReadFile("testdata/replaced-file-1-initial.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				newDefault, err := testdata.ReadFile("testdata/replaced-file-2-new-default.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				current, err := testdata.ReadFile("testdata/replaced-file-3-custom.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				expected, err := testdata.ReadFile("testdata/replaced-file-4-expected-generated.yaml")
+				Expect(err).NotTo(HaveOccurred())
+
+				content, err := meta.ThreeWayMergeManifest(oldDefault, newDefault, current)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal(string(expected)))
+			})
+
+			It("should keep the data section collapsed", func() {
+				oldDefault, err := testdata.ReadFile("testdata/replaced-file-3-custom.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				newDefault, err := testdata.ReadFile("testdata/replaced-file-4-expected-generated.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				current, err := testdata.ReadFile("testdata/replaced-file-1-initial.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				expected, err := testdata.ReadFile("testdata/replaced-file-2-new-default.yaml")
+				Expect(err).NotTo(HaveOccurred())
+
+				content, err := meta.ThreeWayMergeManifest(oldDefault, newDefault, current)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal(string(expected)))
+			})
+		})
 	})
 })

--- a/pkg/utils/meta/testdata/replaced-file-1-initial.yaml
+++ b/pkg/utils/meta/testdata/replaced-file-1-initial.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: garden-test
+data: {}

--- a/pkg/utils/meta/testdata/replaced-file-2-new-default.yaml
+++ b/pkg/utils/meta/testdata/replaced-file-2-new-default.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: garden-test
+data: {a: value}

--- a/pkg/utils/meta/testdata/replaced-file-3-custom.yaml
+++ b/pkg/utils/meta/testdata/replaced-file-3-custom.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: garden-test
+data:
+  another: entry
+type: Opaque

--- a/pkg/utils/meta/testdata/replaced-file-4-expected-generated.yaml
+++ b/pkg/utils/meta/testdata/replaced-file-4-expected-generated.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: garden-test
+data:
+  a: value
+  another: entry
+type: Opaque


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Currently, if the GLK-managed default has e.g., `data: {}` in the manifest, then the merged result will be collapsed/inline instead of expanded.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
