### PR TITLE
Decrease `retryInterval` from `2m` to `30s`

### DIFF
--- a/pkg/components/gardener-extensions/networking-calico/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/networking-calico/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/networking-cilium/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/networking-cilium/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/os-gardenlinux/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/os-gardenlinux/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/os-suse-chost/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/os-suse-chost/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/provider-alicloud/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/provider-alicloud/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/provider-aws/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/provider-aws/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/provider-azure/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/provider-azure/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/provider-gcp/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/provider-gcp/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/provider-openstack/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/provider-openstack/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/runtime-gvisor/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/runtime-gvisor/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/shoot-cert-service/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/shoot-cert-service/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/shoot-dns-service/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/shoot-dns-service/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/shoot-networking-problemdetector/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/shoot-networking-problemdetector/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener-extensions/shoot-oidc-service/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/shoot-oidc-service/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener/garden/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener/garden/templates/landscape/flux-kustomization.yaml
@@ -15,7 +15,7 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 10m
-  retryInterval: 2m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: operator.gardener.cloud/v1alpha1

--- a/pkg/components/gardener/virtual-garden-access/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener/virtual-garden-access/templates/landscape/flux-kustomization.yaml
@@ -15,5 +15,5 @@ spec:
     namespace: garden
   interval: 30m
   timeout: 5m
-  retryInterval: 10m
+  retryInterval: 30s
   wait: true

--- a/pkg/components/virtual-garden/garden-config/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/virtual-garden/garden-config/templates/landscape/flux-kustomization.yaml
@@ -19,7 +19,7 @@ spec:
       key: kubeconfig
   interval: 30m
   timeout: 5m
-  retryInterval: 10m
+  retryInterval: 30s
   wait: true
   healthCheckExprs:
   - apiVersion: core.gardener.cloud/v1beta1


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
Speed up reconciliations by reducing the time waiting for Flux kustomization dependencies.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `retryInterval` is decreased to speed up Flux kustomization reconciliations waiting for dependents.
```
