### PR TITLE
Unignore gardener/gardener submodules on Renovate update (ignore deps generation script)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,10 +44,7 @@ The following dependencies have been updated:\n\
     {
       groupName: 'gardener/gardener',
       matchPackageNames: ['/^(github\\.com\\/)?gardener\\/gardener(\\/.*)?$/'],
-    },
-    {
-      matchPackageNames: ['github.com/gardener/gardener/pkg/apis'],
-      enabled: true,
+      enabled: true
     },
     {
       matchDatasources: ['go'],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,8 +42,12 @@ The following dependencies have been updated:\n\
       enabled: false,
     },
     {
-      groupName: "gardener/gardener",
-      matchPackageNames: ["github.com/gardener/gardener", "gardener/gardener"],
+      groupName: 'gardener/gardener',
+      matchPackageNames: ['/^(github\\.com\\/)?gardener\\/gardener(\\/.*)?$/'],
+    },
+    {
+      matchPackageNames: ['github.com/gardener/gardener/pkg/apis'],
+      enabled: true,
     },
     {
       matchDatasources: ['go'],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,7 +64,6 @@ The following dependencies have been updated:\n\
       matchPackageNames: [ // GENERATOR-PIN
         "github.com/ahmetb/gen-crd-api-reference-docs",
         "github.com/elliotchance/orderedmap/v3",
-        "github.com/gardener/gardener/pkg/apis",
         "github.com/go-logr/logr",
         "github.com/onsi/ginkgo/v2",
         "github.com/onsi/gomega",

--- a/hack/generate-renovate-ignore-deps.sh
+++ b/hack/generate-renovate-ignore-deps.sh
@@ -40,13 +40,16 @@ common_dependencies=()
 for local_dependency in "${local_dependencies[@]}"; do
     for gardener_dependency in "${gardener_dependencies[@]}"; do
         if [[ "$local_dependency" == "$gardener_dependency" ]]; then
-            common_dependencies+=("$local_dependency")
+            # Exclude dependencies starting with github.com/gardener/gardener
+            if [[ ! "$local_dependency" =~ ^github\.com/gardener/gardener ]]; then
+                common_dependencies+=("$local_dependency")
+            fi
             break # Continue with the next element of the outer loop.
         fi
     done
 done
 
-echo "☯️ Found ${#common_dependencies[@]} common dependencies."
+echo "☯️ Found ${#common_dependencies[@]} common dependencies (excluding github.com/gardener/gardener* packages)."
 
 ignore_deps=$(printf ',"%s"' "${common_dependencies[@]}") # Add a comma to the beginning of each element and concatenate them.
 ignore_deps="[${ignore_deps:1}]" # Remove the leading comma and wrap the string in square brackets to format it as a JSON array.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
With the introduction of `pkg/apis` as a submodule to `gardener/gardener`, we must not ignore updates to the submodule (which is added because it is a dependency in `gardener/gardener` itself).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 
fyi @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
