### PR TITLE
Reorder rules and much clearer express that only patch updates should be opened in the release branch `components.yaml`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,20 +31,19 @@ The following dependencies have been updated:\n\
   ],
   packageRules: [
     {
-      matchFileNames: ['!componentvector/components.yaml'],
-      matchBaseBranches: ['/^release-v\\d+\\.\\d+$/'],
-      enabled: false,
-    },
-    {
-      matchFileNames: ['componentvector/components.yaml'],
-      matchBaseBranches: ['/^release-v\\d+\\.\\d+$/'],
-      matchUpdateTypes: ['minor', 'major'],
-      enabled: false,
-    },
-    {
       groupName: 'gardener/gardener',
       matchPackageNames: ['/^(github\\.com\\/)?gardener\\/gardener(\\/.*)?$/'],
       enabled: true
+    },
+    {
+      matchBaseBranches: ['/^release-v\\d+\\.\\d+$/'],
+      enabled: false,
+    },
+    {
+      matchBaseBranches: ['/^release-v\\d+\\.\\d+$/'],
+      matchFileNames: ['componentvector/components.yaml'],
+      matchUpdateTypes: ['patch'],
+      enabled: true,
     },
     {
       matchDatasources: ['go'],


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity delivery
/kind bug enhancement

**What this PR does / why we need it**:
Make Renovate not open updates to release branches other than patches (e.g., https://github.com/gardener/gardener-landscape-kit/pull/159).

According to [the documentation](https://docs.renovatebot.com/configuration-options/#packagerules), the order of `packageRules` matters.

Also, the `patch`-only rule has been made more clear. All other updates to the release branch have been disabled.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 
fyi @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
