### PR TITLE
Include version in component map and allow empty resources

### DIFF
--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -80,7 +80,7 @@ func (r *registry) findAndRenderCustomComponents(opts components.Options) error 
 
 func (r *registry) renderCustomComponents(ocmComponentName, componentDir string, opts components.Options) error {
 	cv := opts.GetComponentVector().FindComponentVector(ocmComponentName)
-	if cv == nil || len(cv.Resources) == 0 {
+	if cv == nil {
 		return fmt.Errorf("no component vector found for custom component %s", ocmComponentName)
 	}
 

--- a/pkg/utils/componentvector/componentvector.go
+++ b/pkg/utils/componentvector/componentvector.go
@@ -37,8 +37,7 @@ func (c *components) FindComponentVersion(name string) (string, bool) {
 // Returns the ComponentVector if found, otherwise nil.
 func (c *components) FindComponentVector(name string) *ComponentVector {
 	if component, exists := c.nameToComponentVector[name]; exists {
-		h := *component
-		return &h
+		return new(*component)
 	}
 	return nil
 }
@@ -84,6 +83,7 @@ func (cv *ComponentVector) TemplateValues() (map[string]any, error) {
 		return nil, fmt.Errorf("failed to convert resources to unstructured map: %w", err)
 	}
 	m := map[string]any{
+		"version":    cv.Version,
 		resourcesKey: resources,
 	}
 	if cv.ImageVectorOverwrite != nil {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This way, we can extract the information of e.g., `github.com/gardener/gardener` and use it as a value in templates of custom components, e.g., to the `gardenlet` version.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 
fyi @MartinWeindel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
