### PR TITLE
Fix `dependsOn` in `garden-config`

### DIFF
--- a/pkg/components/virtual-garden/garden-config/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/virtual-garden/garden-config/templates/landscape/flux-kustomization.yaml
@@ -11,7 +11,7 @@ spec:
   path: {{ .landscapeComponentPath }}
   prune: true
   dependsOn:
-  - name: virtual-garden-access-flux
+  - name: virtual-garden-access
     namespace: garden
   kubeConfig:
     secretRef:


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The renaming of the flux-kustomization  `virtual-garden-access-flux` to `virtual-garden-access` missed to adjust the `dependsOn` field in the `garden-config` flux-kustomization.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related to #166

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
