### PR TITLE
Add e2e test to ensure Flux Kustomizations are reconciled successfully

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
 	github.com/elliotchance/orderedmap/v3 v3.1.0
 	github.com/fluxcd/kustomize-controller/api v1.8.2
+	github.com/fluxcd/pkg/apis/meta v1.25.1
 	github.com/fluxcd/source-controller/api v1.8.1
 	github.com/gardener/gardener v1.137.5
 	github.com/gardener/gardener/pkg/apis v1.137.5
@@ -82,7 +83,6 @@ require (
 	github.com/fluent/fluent-operator/v3 v3.6.0 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.9.0 // indirect
 	github.com/fluxcd/pkg/apis/kustomize v1.15.1 // indirect
-	github.com/fluxcd/pkg/apis/meta v1.25.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gardener/cert-management v0.19.0 // indirect

--- a/test/e2e/glk/create.go
+++ b/test/e2e/glk/create.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	fluxv1 "github.com/fluxcd/kustomize-controller/api/v1"
+	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -19,7 +21,9 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -34,9 +38,13 @@ var _ = Describe("Garden Reconciliation", Label("Garden", "default"), Ordered, f
 	)
 
 	It("Create Kubernetes client", func() {
+		runtimeScheme := runtime.NewScheme()
+		Expect(fluxv1.AddToScheme(runtimeScheme)).To(Succeed())
+		Expect(operatorclient.AddRuntimeSchemeToScheme(runtimeScheme)).To(Succeed())
+
 		var err error
 		runtimeClusterClient, err = kubernetes.NewClientFromFile("", os.Getenv("KUBECONFIG"),
-			kubernetes.WithClientOptions(client.Options{Scheme: operatorclient.RuntimeScheme}),
+			kubernetes.WithClientOptions(client.Options{Scheme: runtimeScheme}),
 			kubernetes.WithClientConnectionOptions(
 				componentbaseconfigv1alpha1.ClientConnectionConfiguration{QPS: 100, Burst: 130}),
 			kubernetes.WithAllowedUserFields([]string{kubernetes.AuthTokenFile}),
@@ -95,6 +103,25 @@ var _ = Describe("Garden Reconciliation", Label("Garden", "default"), Ordered, f
 		Eventually(ctx, func(g Gomega) {
 			g.Eventually(s.VirtualClusterKomega.List(&extOps)).To(Succeed())
 			g.Expect(extOps.Items).To(ConsistOf(expectedExtensions))
+		}).Should(Succeed())
+	})
+
+	It("Ensure that all Flux Kustomizations have been reconciled successfully", func(ctx SpecContext) {
+		Eventually(ctx, func(g Gomega) {
+			var ksList fluxv1.KustomizationList
+			g.Expect(runtimeClusterClient.Client().List(ctx, &ksList)).To(Succeed())
+			g.Expect(ksList.Items).ToNot(BeEmpty())
+
+			for _, ks := range ksList.Items {
+				readyCond := apimeta.FindStatusCondition(ks.Status.Conditions, fluxmeta.ReadyCondition)
+				if !g.Expect(readyCond).ToNot(BeNil(),
+					"Kustomization %s/%s has no Ready condition", ks.Namespace, ks.Name) {
+					continue
+				}
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue),
+					"Kustomization %s/%s is not ready: %s: %s", ks.Namespace, ks.Name,
+					readyCond.Reason, readyCond.Message)
+			}
 		}).Should(Succeed())
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity testing
/kind enhancement

**What this PR does / why we need it**:
Catch instances like https://github.com/gardener/gardener-landscape-kit/pull/186 already in e2e tests: Check that all Flux Kustomizations become ready.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @MartinWeindel

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
