### PR TITLE
Add `.gitattributes` to mark generated files for GitHub PR diffs

### DIFF
--- a/pkg/utils/files/writer.go
+++ b/pkg/utils/files/writer.go
@@ -23,6 +23,9 @@ const (
 	// DefaultDirName is the name of the directory within the GLK system directory that contains the default generated configuration files.
 	DefaultDirName = "defaults"
 
+	// glkGitAttributesContent marks all files under .glk/ as generated so that GitHub collapses them in PR diffs.
+	glkGitAttributesContent = "** linguist-generated=true\n"
+
 	secretEncryptionDisclaimer = `#
 # SECURITY ADVISORY
 #
@@ -46,6 +49,9 @@ func isSecret(contents []byte) bool {
 // Additionally, it maintains a default version of the manifest in a separate directory for future diff checks.
 func WriteObjectsToFilesystem(objects map[string][]byte, rootDir, relativeFilePath string, fs afero.Afero) error {
 	if err := fs.MkdirAll(path.Join(rootDir, relativeFilePath), 0700); err != nil {
+		return err
+	}
+	if err := WriteFileToFilesystem([]byte(glkGitAttributesContent), path.Join(rootDir, GLKSystemDirName, ".gitattributes"), false, fs); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity ops-productivity
/kind enhancement

**What this PR does / why we need it**:
A `.gitattributes` file is written that marks all files under `.glk/` as generated and thus collapses them by default in the diff view on GitHub:
<img width="1690" height="995" alt="image" src="https://github.com/user-attachments/assets/a9e35eae-bcfd-4ed3-a8e3-dc4281199637" />


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Write `.gitattributes` file to hide generated default files under `.glk/`.
```
