### PR TITLE
Add support for OCI registry authentication with environment variables

### DIFF
--- a/docs/usage/custom-ocm-components.md
+++ b/docs/usage/custom-ocm-components.md
@@ -25,10 +25,10 @@ GLK needs two steps to extract and use the information from the OCM component de
 
 To access private OCI registries, GLK reads credentials from two environment variables:
 
-| Variable | Description |
-|---|---|
-| `GLK_OCM_REG_USERNAME` | Registry username |
-| `GLK_OCM_REG_PASSWORD` | Registry password or token |
+| Variable               | Description                |
+|------------------------|----------------------------|
+| `GLK_OCI_REG_USERNAME` | Registry username          |
+| `GLK_OCI_REG_PASSWORD` | Registry password or token |
 
 Both variables must be set to access private registries. Without them, only anonymous access is attempted.
 
@@ -37,7 +37,7 @@ Both variables must be set to access private registries. Without them, only anon
 ```bash
 # Authenticate with gcloud and export credentials for GLK
 gcloud auth login
-eval "$(echo "europe-docker.pkg.dev" | docker-credential-gcloud get | jq -r '"export GLK_OCM_REG_USERNAME=\(.Username)\nexport GLK_OCM_REG_PASSWORD=\(.Secret)"')"
+eval "$(echo "europe-docker.pkg.dev" | docker-credential-gcloud get | jq -r '"export GLK_OCI_REG_USERNAME=\(.Username)\nexport GLK_OCI_REG_PASSWORD=\(.Secret)"')"
 ```
 
 > [!NOTE]

--- a/docs/usage/custom-ocm-components.md
+++ b/docs/usage/custom-ocm-components.md
@@ -21,6 +21,30 @@ GLK needs two steps to extract and use the information from the OCM component de
    - The extracted information is written to `components.yaml` in the provided landscape (or base) directory.
 2. The command `glk generate [base|landscape]` generates the Flux kustomizations for its active components and additionally renders templates for custom OCM components.
 
+### OCI Registry Authentication
+
+To access private OCI registries, GLK reads credentials from two environment variables:
+
+| Variable | Description |
+|---|---|
+| `GLK_OCM_REG_USERNAME` | Registry username |
+| `GLK_OCM_REG_PASSWORD` | Registry password or token |
+
+Both variables must be set to access private registries. Without them, only anonymous access is attempted.
+
+#### Example: Google Artifact Registry / GCR
+
+```bash
+# Authenticate with gcloud and export credentials for GLK
+gcloud auth login
+eval "$(echo "europe-docker.pkg.dev" | docker-credential-gcloud get | jq -r '"export GLK_OCM_REG_USERNAME=\(.Username)\nexport GLK_OCM_REG_PASSWORD=\(.Secret)"')"
+```
+
+> [!NOTE]
+> Replace `europe-docker.pkg.dev` with your registry host if it differs.
+
+After exporting the variables, run `glk resolve ocm` as usual.
+
 ### Example
 
 Assuming you have a custom OCM component named `my.private-github.com/gardener/my-gardener-extension` stored in a private OCI registry and it is somehow referenced in the OCM descriptor tree starting from the root component descriptor `my.private-github.com/gardener/my-root-compoment`.

--- a/pkg/ocm/ociaccess/repoaccess.go
+++ b/pkg/ocm/ociaccess/repoaccess.go
@@ -31,7 +31,7 @@ const (
 	// GlkOcmRegUsernameEnvKey is the environment variable for the OCI registry username.
 	GlkOcmRegUsernameEnvKey = "GLK_OCM_REG_USERNAME"
 	// GlkOcmRegPasswordEnvKey is the environment variable for the OCI registry password or token.
-	GlkOcmRegPasswordEnvKey = "GLK_OCM_REG_PASSWORD"
+	GlkOcmRegPasswordEnvKey = "GLK_OCM_REG_PASSWORD" // #nosec: G101 -- just the env var name, not the value
 
 	userAgentPrefix = "gardener-landscape-kit/"
 )

--- a/pkg/ocm/ociaccess/repoaccess.go
+++ b/pkg/ocm/ociaccess/repoaccess.go
@@ -27,7 +27,14 @@ import (
 	"oras.land/oras-go/v2/registry/remote/retry"
 )
 
-const userAgentPrefix = "gardener-landscape-kit/"
+const (
+	// GlkOcmRegUsernameEnvKey is the environment variable for the OCI registry username.
+	GlkOcmRegUsernameEnvKey = "GLK_OCM_REG_USERNAME"
+	// GlkOcmRegPasswordEnvKey is the environment variable for the OCI registry password or token.
+	GlkOcmRegPasswordEnvKey = "GLK_OCM_REG_PASSWORD"
+
+	userAgentPrefix = "gardener-landscape-kit/"
+)
 
 // DefaultScheme is the scheme used by RepoAccess.
 var DefaultScheme = ocmruntime.NewScheme()
@@ -56,9 +63,8 @@ func NewRepoAccess(repositoryURL string) (*RepoAccess, error) {
 		return nil, fmt.Errorf("failed to create URL resolver: %w", err)
 	}
 
-	// TODO (MartinWeindel): Support other authentication methods.
-	user := "_json_key"
-	password := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	user := os.Getenv(GlkOcmRegUsernameEnvKey)
+	password := os.Getenv(GlkOcmRegPasswordEnvKey)
 	resolver.SetClient(CreateAuthClient(repositoryURL, user, password))
 
 	logOutput := &bytes.Buffer{}

--- a/pkg/ocm/ociaccess/repoaccess.go
+++ b/pkg/ocm/ociaccess/repoaccess.go
@@ -28,10 +28,10 @@ import (
 )
 
 const (
-	// GlkOCMRegUsernameEnvKey is the environment variable for the OCI registry username.
-	GlkOCMRegUsernameEnvKey = "GLK_OCM_REG_USERNAME"
-	// GlkOCMRegPasswordEnvKey is the environment variable for the OCI registry password or token.
-	GlkOCMRegPasswordEnvKey = "GLK_OCM_REG_PASSWORD" // #nosec: G101 -- just the env var name, not the value
+	// OCIRegUsernameEnvKey is the environment variable for the OCI registry username.
+	OCIRegUsernameEnvKey = "GLK_OCI_REG_USERNAME"
+	// OCIRegPasswordEnvKey is the environment variable for the OCI registry password or token.
+	OCIRegPasswordEnvKey = "GLK_OCI_REG_PASSWORD" // #nosec: G101 -- just the env var name, not the value
 
 	userAgentPrefix = "gardener-landscape-kit/"
 )
@@ -63,8 +63,8 @@ func NewRepoAccess(repositoryURL string) (*RepoAccess, error) {
 		return nil, fmt.Errorf("failed to create URL resolver: %w", err)
 	}
 
-	user := os.Getenv(GlkOCMRegUsernameEnvKey)
-	password := os.Getenv(GlkOCMRegPasswordEnvKey)
+	user := os.Getenv(OCIRegUsernameEnvKey)
+	password := os.Getenv(OCIRegPasswordEnvKey)
 	resolver.SetClient(CreateAuthClient(repositoryURL, user, password))
 
 	logOutput := &bytes.Buffer{}

--- a/pkg/ocm/ociaccess/repoaccess.go
+++ b/pkg/ocm/ociaccess/repoaccess.go
@@ -28,10 +28,10 @@ import (
 )
 
 const (
-	// GlkOcmRegUsernameEnvKey is the environment variable for the OCI registry username.
-	GlkOcmRegUsernameEnvKey = "GLK_OCM_REG_USERNAME"
-	// GlkOcmRegPasswordEnvKey is the environment variable for the OCI registry password or token.
-	GlkOcmRegPasswordEnvKey = "GLK_OCM_REG_PASSWORD" // #nosec: G101 -- just the env var name, not the value
+	// GlkOCMRegUsernameEnvKey is the environment variable for the OCI registry username.
+	GlkOCMRegUsernameEnvKey = "GLK_OCM_REG_USERNAME"
+	// GlkOCMRegPasswordEnvKey is the environment variable for the OCI registry password or token.
+	GlkOCMRegPasswordEnvKey = "GLK_OCM_REG_PASSWORD" // #nosec: G101 -- just the env var name, not the value
 
 	userAgentPrefix = "gardener-landscape-kit/"
 )
@@ -63,8 +63,8 @@ func NewRepoAccess(repositoryURL string) (*RepoAccess, error) {
 		return nil, fmt.Errorf("failed to create URL resolver: %w", err)
 	}
 
-	user := os.Getenv(GlkOcmRegUsernameEnvKey)
-	password := os.Getenv(GlkOcmRegPasswordEnvKey)
+	user := os.Getenv(GlkOCMRegUsernameEnvKey)
+	password := os.Getenv(GlkOCMRegPasswordEnvKey)
 	resolver.SetClient(CreateAuthClient(repositoryURL, user, password))
 
 	logOutput := &bytes.Buffer{}

--- a/pkg/ocm/resolve.go
+++ b/pkg/ocm/resolve.go
@@ -42,8 +42,8 @@ type ocmComponentsResolver struct {
 func ResolveOCMComponents(log logr.Logger, cfg *configv1alpha1.LandscapeKitConfiguration, landscapeDir, outputDir string,
 	workers int, debug bool) error {
 	// TODO (MartinWeindel): This is a temporary workaround to inform users about potential authentication issues.
-	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
-		log.Info("Warning: Environment variable GOOGLE_APPLICATION_CREDENTIALS is not set. Accessing private GCR repositories may fail.")
+	if os.Getenv(ociaccess.GlkOcmRegUsernameEnvKey) == "" || os.Getenv(ociaccess.GlkOcmRegPasswordEnvKey) == "" {
+		log.Info("Warning: Environment variables " + ociaccess.GlkOcmRegUsernameEnvKey + " and/or " + ociaccess.GlkOcmRegPasswordEnvKey + " are not set. Accessing private OCI repositories may fail.")
 	}
 
 	repos, err := createRepoAccesses(cfg.OCM)

--- a/pkg/ocm/resolve.go
+++ b/pkg/ocm/resolve.go
@@ -42,8 +42,8 @@ type ocmComponentsResolver struct {
 func ResolveOCMComponents(log logr.Logger, cfg *configv1alpha1.LandscapeKitConfiguration, landscapeDir, outputDir string,
 	workers int, debug bool) error {
 	// TODO (MartinWeindel): This is a temporary workaround to inform users about potential authentication issues.
-	if os.Getenv(ociaccess.GlkOCMRegUsernameEnvKey) == "" || os.Getenv(ociaccess.GlkOCMRegPasswordEnvKey) == "" {
-		log.Info("Warning: Environment variables " + ociaccess.GlkOCMRegUsernameEnvKey + " and/or " + ociaccess.GlkOCMRegPasswordEnvKey + " are not set. Accessing private OCI repositories may fail.")
+	if os.Getenv(ociaccess.OCIRegUsernameEnvKey) == "" || os.Getenv(ociaccess.OCIRegPasswordEnvKey) == "" {
+		log.Info("Warning: Environment variables " + ociaccess.OCIRegUsernameEnvKey + " and/or " + ociaccess.OCIRegPasswordEnvKey + " are not set. Accessing private OCI repositories may fail.")
 	}
 
 	repos, err := createRepoAccesses(cfg.OCM)

--- a/pkg/ocm/resolve.go
+++ b/pkg/ocm/resolve.go
@@ -42,8 +42,8 @@ type ocmComponentsResolver struct {
 func ResolveOCMComponents(log logr.Logger, cfg *configv1alpha1.LandscapeKitConfiguration, landscapeDir, outputDir string,
 	workers int, debug bool) error {
 	// TODO (MartinWeindel): This is a temporary workaround to inform users about potential authentication issues.
-	if os.Getenv(ociaccess.GlkOcmRegUsernameEnvKey) == "" || os.Getenv(ociaccess.GlkOcmRegPasswordEnvKey) == "" {
-		log.Info("Warning: Environment variables " + ociaccess.GlkOcmRegUsernameEnvKey + " and/or " + ociaccess.GlkOcmRegPasswordEnvKey + " are not set. Accessing private OCI repositories may fail.")
+	if os.Getenv(ociaccess.GlkOCMRegUsernameEnvKey) == "" || os.Getenv(ociaccess.GlkOCMRegPasswordEnvKey) == "" {
+		log.Info("Warning: Environment variables " + ociaccess.GlkOCMRegUsernameEnvKey + " and/or " + ociaccess.GlkOCMRegPasswordEnvKey + " are not set. Accessing private OCI repositories may fail.")
 	}
 
 	repos, err := createRepoAccesses(cfg.OCM)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Currently, the setup is hardcoded to Google/GCR.
With this PR, the authentication is provided via generic environment variables.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy @MartinWeindel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Environment variable `GOOGLE_APPLICATION_CREDENTIALS` is replaced by `GLK_OCI_REG_USERNAME` and `GLK_OCI_REG_PASSWORD` for authenticating against OCI registries in the `resolve ocm` command.
```
