### PR TITLE
Change custom component template suffix from `.template` to `.tpl`

### DIFF
--- a/docs/usage/custom-ocm-components.md
+++ b/docs/usage/custom-ocm-components.md
@@ -9,7 +9,7 @@ But if your component is backed by an OCM component descriptor, you can benefit 
 
 1. The component directory contains a file named `component-name` containing the OCM component name (e.g. `my.private-github.com/gardener/my-gardener-extension`).
 2. The custom component must be included in the OCM descriptor tree. This means it must be referenced by the root component descriptor or any component referenced directly or indirectly.
-3. The component directory contains template files with suffix `.template` (e.g. `my-extension-deployment.yaml.template`). It can reference values for resources or image vector overrides as extracted from the OCM component descriptor.
+3. The component directory contains template files with suffix `.tpl` (e.g. `my-extension-deployment.yaml.tpl`). It can reference values for resources or image vector overrides as extracted from the OCM component descriptor.
 
 ### How it works
 
@@ -43,7 +43,7 @@ ocm:
 ```
 components/my-gardener-extension
   ├── component-name
-  ├── my-extension-deployment.yaml.template
+  ├── my-extension-deployment.yaml.tpl
   ├── kustomization.yaml
   ...
 ```
@@ -60,7 +60,7 @@ glk resolve ocm -c landscapekitconfiguration.yaml --target-dir /path/to/landscap
 
 4. Make use of the extracted resource information stored in the file `ocm-components.yaml`.
 
-If your component is a gardener extension, the `my-extension-deployment.yaml.template` may look like this:
+If your component is a gardener extension, the `my-extension-deployment.yaml.tpl` may look like this:
 ```yaml
 apiVersion: operator.gardener.cloud/v1alpha1
 kind: Extension

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -19,6 +19,8 @@ import (
 const (
 	// CustomComponentNameFilename is the filename containing a custom OCM component name.
 	CustomComponentNameFilename = "component-name"
+	// TemplateSuffix is the file extension used to identify custom component template files.
+	TemplateSuffix = ".tpl"
 )
 
 // Interface is the interface for a component registry.
@@ -92,7 +94,7 @@ func (r *registry) renderCustomComponents(ocmComponentName, componentDir string,
 		if err != nil {
 			return err
 		}
-		if info.IsDir() || !strings.HasSuffix(info.Name(), ".template") {
+		if info.IsDir() || !strings.HasSuffix(info.Name(), TemplateSuffix) {
 			return nil
 		}
 		content, err := opts.GetFilesystem().ReadFile(path)
@@ -107,7 +109,7 @@ func (r *registry) renderCustomComponents(ocmComponentName, componentDir string,
 		if err != nil {
 			return fmt.Errorf("error rendering template file %s for custom component %s: %w", path, ocmComponentName, err)
 		}
-		targetFile := strings.TrimSuffix(path, ".template")
+		targetFile := strings.TrimSuffix(path, TemplateSuffix)
 		if err := opts.GetFilesystem().WriteFile(targetFile, renderedContent, 0600); err != nil {
 			return fmt.Errorf("error writing rendered template file %s for custom component %s: %w", targetFile, ocmComponentName, err)
 		}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Extract the template suffix into a central `TemplateSuffix` constant in `pkg/registry` and switch the default from `.template` to `.tpl`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
Decided to not draft release note, as the `.template` suffix was also only added in e3a759ec20adfec2150454f0b174b85358d27b6c.
