### PR TITLE
Introduce `--ignore-missing-components` option for `resolve ocm` command.

### DIFF
--- a/docs/api-reference/landscapekit-v1alpha1.md
+++ b/docs/api-reference/landscapekit-v1alpha1.md
@@ -131,6 +131,7 @@ _Appears in:_
 | `repositories` _string array_ | Repositories is a map from repository name to URL. |  |  |
 | `rootComponent` _[OCMComponent](#ocmcomponent)_ | RootComponent is the configuration of the root component. |  |  |
 | `originalRefs` _boolean_ | OriginalRefs is a flag to output original image references in the image vectors. |  |  |
+| `ignoreMissingComponents` _boolean_ | IgnoreMissingComponents indicates whether to ignore missing components during resolution. |  | Optional: \{\} <br /> |
 
 
 #### PathConfiguration

--- a/example/20-componentconfig-glk.yaml
+++ b/example/20-componentconfig-glk.yaml
@@ -7,6 +7,7 @@ kind: LandscapeKitConfiguration
 #     name: <component-name>
 #     version: <component-version>
 #   originalRefs: true
+#   ignoreMissingComponents: false
 # git:
 #   url: https://github.com/<org>/<repo>
 #   ref:

--- a/hack/resolve-public-ocm-component.sh
+++ b/hack/resolve-public-ocm-component.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -lt 2 ]]; then
+  cat <<USAGE
+Usage: $0 <componentName> <componentVersion>
+
+Description:
+  Resolves an OCM component descriptor from the public Gardener releases repository
+  and outputs the extracted components.yaml file.
+
+Arguments:
+  <componentName>     The name of the OCM component to resolve
+                      (e.g., github.com/gardener/gardener-extension-provider-aws)
+  <componentVersion>  The version of the component to resolve
+                      (e.g., v1.68.3)
+
+Output:
+  Prints the components.yaml file extracted from the public OCM component descriptor
+  to stdout. This file contains the resolved component references and dependencies.
+
+Example:
+  $0 github.com/gardener/gardener-extension-provider-aws v1.68.3
+
+Notes:
+  - Fetches component descriptors from: oci://europe-docker.pkg.dev/gardener-project/releases
+  - Uses temporary directory for intermediate files (automatically cleaned up)
+  - Runs 'resolve ocm' command with --ignore-missing-components flag
+USAGE
+  exit 1
+fi
+
+componentName="$1"
+componentVersion="$2"
+
+# make temp dir for the resolved components
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat <<EOF > "$tmp_dir/landscapekitconfiguration.yaml"
+apiVersion: landscape.config.gardener.cloud/v1alpha1
+kind: LandscapeKitConfiguration
+ocm:
+  repositories:
+    - oci://europe-docker.pkg.dev/gardener-project/releases
+  rootComponent:
+    name: $componentName
+    version: $componentVersion
+EOF
+
+# Fake component as custom OCM component, to be resolved by the landscapekit and written to the components vector file.
+echo $componentName > "$tmp_dir/ocm-component-name"
+
+go run ./cmd/gardener-landscape-kit resolve ocm -c "$tmp_dir/landscapekitconfiguration.yaml" -d "$tmp_dir" --ignore-missing-components > /dev/null
+
+cat "$tmp_dir/components.yaml"

--- a/hack/resolve-public-ocm-component.sh
+++ b/hack/resolve-public-ocm-component.sh
@@ -32,7 +32,7 @@ Example:
 Notes:
   - Fetches component descriptors from: oci://europe-docker.pkg.dev/gardener-project/releases
   - Uses temporary directory for intermediate files (automatically cleaned up)
-  - Runs 'resolve ocm' command with --ignore-missing-components flag
+  - Runs 'resolve ocm' command with ignoreMissingComponents set to true in configuration
 USAGE
   exit 1
 fi
@@ -53,11 +53,12 @@ ocm:
   rootComponent:
     name: $componentName
     version: $componentVersion
+  ignoreMissingComponents: true
 EOF
 
 # Fake component as custom OCM component, to be resolved by the landscapekit and written to the components vector file.
 echo $componentName > "$tmp_dir/ocm-component-name"
 
-go run ./cmd/gardener-landscape-kit resolve ocm -c "$tmp_dir/landscapekitconfiguration.yaml" -d "$tmp_dir" --ignore-missing-components > /dev/null
+go run ./cmd/gardener-landscape-kit resolve ocm -c "$tmp_dir/landscapekitconfiguration.yaml" -d "$tmp_dir" > /dev/null
 
 cat "$tmp_dir/components.yaml"

--- a/pkg/apis/config/v1alpha1/defaults.go
+++ b/pkg/apis/config/v1alpha1/defaults.go
@@ -17,3 +17,10 @@ func SetDefaults_LandscapeKitConfiguration(obj *LandscapeKitConfiguration) {
 		obj.MergeMode = new(MergeModeHint)
 	}
 }
+
+// SetDefaults_OCMConfig sets defaults for OCMConfig.
+func SetDefaults_OCMConfig(obj *OCMConfig) {
+	if obj.IgnoreMissingComponents == nil {
+		obj.IgnoreMissingComponents = new(false)
+	}
+}

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -88,6 +88,9 @@ type OCMConfig struct {
 	RootComponent OCMComponent `json:"rootComponent"`
 	// OriginalRefs is a flag to output original image references in the image vectors.
 	OriginalRefs bool `json:"originalRefs"`
+	// IgnoreMissingComponents indicates whether to ignore missing components during resolution.
+	// +optional
+	IgnoreMissingComponents *bool `json:"ignoreMissingComponents,omitempty"`
 }
 
 // OCMComponent specifies a OCM component.

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -163,6 +163,11 @@ func (in *OCMConfig) DeepCopyInto(out *OCMConfig) {
 		copy(*out, *in)
 	}
 	out.RootComponent = in.RootComponent
+	if in.IgnoreMissingComponents != nil {
+		in, out := &in.IgnoreMissingComponents, &out.IgnoreMissingComponents
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.defaults.go
@@ -23,4 +23,7 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_LandscapeKitConfiguration(in *LandscapeKitConfiguration) {
 	SetDefaults_LandscapeKitConfiguration(in)
+	if in.OCM != nil {
+		SetDefaults_OCMConfig(in.OCM)
+	}
 }

--- a/pkg/cmd/resolve/ocm/ocm.go
+++ b/pkg/cmd/resolve/ocm/ocm.go
@@ -48,8 +48,6 @@ type Options struct {
 	Debug bool
 	// Workers is the number of concurrent workers to use for resolving OCM components.
 	Workers int
-	// IgnoreMissingComponents indicates whether to ignore missing components during resolution.
-	IgnoreMissingComponents bool
 }
 
 // NewCommand creates a new cobra.Command for running gardener-landscape-kit resolve ocm.
@@ -112,7 +110,6 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.ConfigFilePath, "config", "c", o.ConfigFilePath, "Path to configuration file.")
 	fs.BoolVar(&o.Debug, "debug", false, "Enable debug output files like resources and imagevectors.")
 	fs.IntVar(&o.Workers, "workers", 10, "Number of concurrent workers to use for resolving OCM components.")
-	fs.BoolVar(&o.IgnoreMissingComponents, "ignore-missing-components", false, "Ignore missing components during resolution. By default, the command will fail if a component cannot be resolved or is not referenced.")
 }
 
 func (o *Options) effectiveIntermediateOutputDir() string {
@@ -144,7 +141,7 @@ func run(_ context.Context, opts *Options) error {
 	if err := writeGitIgnoreFile(opts); err != nil {
 		return err
 	}
-	return ocm.ResolveOCMComponents(opts.Log, opts.Config, opts.TargetDirPath, outputDir, opts.Workers, opts.Debug, opts.IgnoreMissingComponents)
+	return ocm.ResolveOCMComponents(opts.Log, opts.Config, opts.TargetDirPath, outputDir, opts.Workers, opts.Debug)
 }
 
 func writeGitIgnoreFile(opts *Options) error {

--- a/pkg/cmd/resolve/ocm/ocm.go
+++ b/pkg/cmd/resolve/ocm/ocm.go
@@ -48,6 +48,8 @@ type Options struct {
 	Debug bool
 	// Workers is the number of concurrent workers to use for resolving OCM components.
 	Workers int
+	// IgnoreMissingComponents indicates whether to ignore missing components during resolution.
+	IgnoreMissingComponents bool
 }
 
 // NewCommand creates a new cobra.Command for running gardener-landscape-kit resolve ocm.
@@ -110,6 +112,7 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.ConfigFilePath, "config", "c", o.ConfigFilePath, "Path to configuration file.")
 	fs.BoolVar(&o.Debug, "debug", false, "Enable debug output files like resources and imagevectors.")
 	fs.IntVar(&o.Workers, "workers", 10, "Number of concurrent workers to use for resolving OCM components.")
+	fs.BoolVar(&o.IgnoreMissingComponents, "ignore-missing-components", false, "Ignore missing components during resolution. By default, the command will fail if a component cannot be resolved or is not referenced.")
 }
 
 func (o *Options) effectiveIntermediateOutputDir() string {
@@ -141,7 +144,7 @@ func run(_ context.Context, opts *Options) error {
 	if err := writeGitIgnoreFile(opts); err != nil {
 		return err
 	}
-	return ocm.ResolveOCMComponents(opts.Log, opts.Config, opts.TargetDirPath, outputDir, opts.Workers, opts.Debug)
+	return ocm.ResolveOCMComponents(opts.Log, opts.Config, opts.TargetDirPath, outputDir, opts.Workers, opts.Debug, opts.IgnoreMissingComponents)
 }
 
 func writeGitIgnoreFile(opts *Options) error {

--- a/pkg/ocm/resolve.go
+++ b/pkg/ocm/resolve.go
@@ -27,20 +27,21 @@ import (
 )
 
 type ocmComponentsResolver struct {
-	log          logr.Logger
-	cfg          *configv1alpha1.LandscapeKitConfiguration
-	landscapeDir string
-	outputDir    string
-	debug        bool
-	workers      int
-	components   *components.Components
-	repos        []*ociaccess.RepoAccess
+	log                     logr.Logger
+	cfg                     *configv1alpha1.LandscapeKitConfiguration
+	landscapeDir            string
+	outputDir               string
+	debug                   bool
+	ignoreMissingComponents bool
+	workers                 int
+	components              *components.Components
+	repos                   []*ociaccess.RepoAccess
 }
 
 // ResolveOCMComponents resolves OCM components starting from a root component, processes their dependencies,
 // and writes component descriptors and image vectors to the specified output directory.
 func ResolveOCMComponents(log logr.Logger, cfg *configv1alpha1.LandscapeKitConfiguration, landscapeDir, outputDir string,
-	workers int, debug bool) error {
+	workers int, debug, ignoreMissingComponents bool) error {
 	// TODO (MartinWeindel): This is a temporary workaround to inform users about potential authentication issues.
 	if os.Getenv(ociaccess.OCIRegUsernameEnvKey) == "" || os.Getenv(ociaccess.OCIRegPasswordEnvKey) == "" {
 		log.Info("Warning: Environment variables " + ociaccess.OCIRegUsernameEnvKey + " and/or " + ociaccess.OCIRegPasswordEnvKey + " are not set. Accessing private OCI repositories may fail.")
@@ -52,14 +53,15 @@ func ResolveOCMComponents(log logr.Logger, cfg *configv1alpha1.LandscapeKitConfi
 	}
 
 	resolver := &ocmComponentsResolver{
-		log:          log,
-		cfg:          cfg,
-		landscapeDir: landscapeDir,
-		outputDir:    outputDir,
-		debug:        debug,
-		workers:      workers,
-		components:   components.NewComponents(),
-		repos:        repos,
+		log:                     log,
+		cfg:                     cfg,
+		landscapeDir:            landscapeDir,
+		outputDir:               outputDir,
+		debug:                   debug,
+		ignoreMissingComponents: ignoreMissingComponents,
+		workers:                 workers,
+		components:              components.NewComponents(),
+		repos:                   repos,
 	}
 
 	ctx := context.Background()
@@ -204,7 +206,7 @@ func (r *ocmComponentsResolver) writeLandscapeKitComponents() error {
 	if err != nil {
 		return err
 	}
-	componentVersions, err := r.components.GetGLKComponents(customComponents, false)
+	componentVersions, err := r.components.GetGLKComponents(customComponents, r.ignoreMissingComponents)
 	if err != nil {
 		return err
 	}

--- a/pkg/ocm/resolve.go
+++ b/pkg/ocm/resolve.go
@@ -27,21 +27,20 @@ import (
 )
 
 type ocmComponentsResolver struct {
-	log                     logr.Logger
-	cfg                     *configv1alpha1.LandscapeKitConfiguration
-	landscapeDir            string
-	outputDir               string
-	debug                   bool
-	ignoreMissingComponents bool
-	workers                 int
-	components              *components.Components
-	repos                   []*ociaccess.RepoAccess
+	log          logr.Logger
+	cfg          *configv1alpha1.LandscapeKitConfiguration
+	landscapeDir string
+	outputDir    string
+	debug        bool
+	workers      int
+	components   *components.Components
+	repos        []*ociaccess.RepoAccess
 }
 
 // ResolveOCMComponents resolves OCM components starting from a root component, processes their dependencies,
 // and writes component descriptors and image vectors to the specified output directory.
 func ResolveOCMComponents(log logr.Logger, cfg *configv1alpha1.LandscapeKitConfiguration, landscapeDir, outputDir string,
-	workers int, debug, ignoreMissingComponents bool) error {
+	workers int, debug bool) error {
 	// TODO (MartinWeindel): This is a temporary workaround to inform users about potential authentication issues.
 	if os.Getenv(ociaccess.OCIRegUsernameEnvKey) == "" || os.Getenv(ociaccess.OCIRegPasswordEnvKey) == "" {
 		log.Info("Warning: Environment variables " + ociaccess.OCIRegUsernameEnvKey + " and/or " + ociaccess.OCIRegPasswordEnvKey + " are not set. Accessing private OCI repositories may fail.")
@@ -53,15 +52,14 @@ func ResolveOCMComponents(log logr.Logger, cfg *configv1alpha1.LandscapeKitConfi
 	}
 
 	resolver := &ocmComponentsResolver{
-		log:                     log,
-		cfg:                     cfg,
-		landscapeDir:            landscapeDir,
-		outputDir:               outputDir,
-		debug:                   debug,
-		ignoreMissingComponents: ignoreMissingComponents,
-		workers:                 workers,
-		components:              components.NewComponents(),
-		repos:                   repos,
+		log:          log,
+		cfg:          cfg,
+		landscapeDir: landscapeDir,
+		outputDir:    outputDir,
+		debug:        debug,
+		workers:      workers,
+		components:   components.NewComponents(),
+		repos:        repos,
 	}
 
 	ctx := context.Background()
@@ -206,7 +204,7 @@ func (r *ocmComponentsResolver) writeLandscapeKitComponents() error {
 	if err != nil {
 		return err
 	}
-	componentVersions, err := r.components.GetGLKComponents(customComponents, r.ignoreMissingComponents)
+	componentVersions, err := r.components.GetGLKComponents(customComponents, *r.cfg.OCM.IgnoreMissingComponents)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Introduce `--ignore-missing-components` option for `resolve ocm` command. If set, missing components are silently ignored during resolution.

Additionally, the script `hack/resolve-public-ocm-component.sh` was added to quickly see resulting section in `components.yaml` for a given component as resolved from the public Gardener release repository.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
