### PR TITLE
Add Forgejo Runner for Local Setup

### DIFF
--- a/dev-setup/git-server/Readme.md
+++ b/dev-setup/git-server/Readme.md
@@ -13,9 +13,6 @@ http://git.local.gardener.cloud:6080/gitops
 > Password: `testtest`
 ```
 
-> [!NOTE]
-> Ensure that the host `git.local.gardener.cloud` resolves to `127.0.0.1`
-
 ## Clone
 
 - Base repo

--- a/dev-setup/git-server/docker-compose.yaml
+++ b/dev-setup/git-server/docker-compose.yaml
@@ -2,21 +2,61 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+volumes:
+  docker_certs:
+
 services:
   git:
     container_name: glk-git-server
     image: codeberg.org/forgejo/forgejo:15.0.0
     ports:
-      - "6080:6080"
+    - "6080:6080"
     volumes:
-      - ./forgejo.conf:/app.ini.sample:ro
-      - ../../dev/git-server/data:/data
-      - ./entrypoint.sh:/entrypoint.sh:ro
+    - ./forgejo.conf:/app.ini.sample:ro
+    - ./runner-config.yaml:/runner-config.yaml:ro
+    - ../../dev/git-server/data:/data
+    - ./entrypoint.sh:/entrypoint.sh:ro
     entrypoint: ["/bin/sh", "/entrypoint.sh"]
+    healthcheck:
+      test: [ "CMD-SHELL", "test -f /data/runner/config.yaml" ]
+      interval: 10s
+      retries: 5
+      start_period: 5s
+      timeout: 10s
     networks:
       kind:
         aliases:
-          - git.local.gardener.cloud
+        - git.local.gardener.cloud
+
+  docker-in-docker:
+    image: data.forgejo.org/oci/docker:dind
+    hostname: docker  # Must set hostname as TLS certificates are only valid for docker or localhost
+    privileged: true
+    environment:
+      DOCKER_TLS_CERTDIR: /certs
+      DOCKER_HOST: docker-in-docker
+    volumes:
+    - docker_certs:/certs
+    networks:
+      kind:
+
+  runner:
+    image: data.forgejo.org/forgejo/runner:12.7.2
+    environment:
+      DOCKER_HOST: tcp://docker:2376
+      DOCKER_CERT_PATH: /certs/client
+      DOCKER_TLS_VERIFY: "1"
+    volumes:
+    - ../../dev/git-server/data/runner:/data
+    - docker_certs:/certs
+    restart: unless-stopped
+    depends_on:
+      git:
+        condition: service_healthy
+    command: >-
+      forgejo-runner --config /data/config.yaml daemon
+    networks:
+      kind:
 
 networks:
   kind:

--- a/dev-setup/git-server/docker-compose.yaml
+++ b/dev-setup/git-server/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       test: [ "CMD-SHELL", "test -f /data/runner/config.yaml" ]
       interval: 10s
       retries: 5
-      start_period: 5s
+      start_period: 2s
       timeout: 10s
     networks:
       kind:

--- a/dev-setup/git-server/docker-compose.yaml
+++ b/dev-setup/git-server/docker-compose.yaml
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-volumes:
-  docker_certs:
-
 services:
-  git:
-    container_name: glk-git-server
+  forgejo:
+    container_name: glk-forgejo
     image: codeberg.org/forgejo/forgejo:15.0.0
+    healthcheck:
+      test: [ "CMD-SHELL", "test -f /data/runner/config.yaml" ]
+      interval: 10s
+      retries: 5
+      start_period: 2s
+      timeout: 10s
     ports:
     - "6080:6080"
     volumes:
@@ -16,19 +19,14 @@ services:
     - ./runner-config.yaml:/runner-config.yaml:ro
     - ../../dev/git-server/data:/data
     - ./entrypoint.sh:/entrypoint.sh:ro
-    entrypoint: ["/bin/sh", "/entrypoint.sh"]
-    healthcheck:
-      test: [ "CMD-SHELL", "test -f /data/runner/config.yaml" ]
-      interval: 10s
-      retries: 5
-      start_period: 2s
-      timeout: 10s
+    restart: unless-stopped
     networks:
-      kind:
+      default:
         aliases:
         - git.local.gardener.cloud
 
   docker-in-docker:
+    container_name: glk-forgejo-dind
     image: data.forgejo.org/oci/docker:dind
     hostname: docker  # Must set hostname as TLS certificates are only valid for docker or localhost
     privileged: true
@@ -36,29 +34,29 @@ services:
       DOCKER_TLS_CERTDIR: /certs
       DOCKER_HOST: docker-in-docker
     volumes:
-    - docker_certs:/certs
-    networks:
-      kind:
+    - ../../dev/git-server/data/docker_certs:/certs
+    restart: unless-stopped
 
   runner:
+    container_name: glk-forgejo-runner
     image: data.forgejo.org/forgejo/runner:12.7.2
+    command: >-
+      forgejo-runner --config /data/config.yaml daemon
     environment:
       DOCKER_HOST: tcp://docker:2376
       DOCKER_CERT_PATH: /certs/client
       DOCKER_TLS_VERIFY: "1"
     volumes:
     - ../../dev/git-server/data/runner:/data
-    - docker_certs:/certs
+    - ../../dev/git-server/data/docker_certs:/certs
     restart: unless-stopped
     depends_on:
-      git:
+      forgejo:
         condition: service_healthy
-    command: >-
-      forgejo-runner --config /data/config.yaml daemon
-    networks:
-      kind:
+      docker-in-docker:
+        condition: service_started
 
 networks:
-  kind:
+  default:
     external: true
     name: kind

--- a/dev-setup/git-server/docker-compose.yaml
+++ b/dev-setup/git-server/docker-compose.yaml
@@ -6,8 +6,9 @@ services:
   forgejo:
     container_name: glk-forgejo
     image: codeberg.org/forgejo/forgejo:15.0.0
+    entrypoint: [ "/bin/sh", "/entrypoint.sh" ]
     healthcheck:
-      test: [ "CMD-SHELL", "test -f /data/runner/config.yaml" ]
+      test: [ "CMD-SHELL", "test -f /runner/config.yaml" ]
       interval: 10s
       retries: 5
       start_period: 2s
@@ -18,6 +19,7 @@ services:
     - ./forgejo.conf:/app.ini.sample:ro
     - ./runner-config.yaml:/runner-config.yaml:ro
     - ../../dev/git-server/data:/data
+    - ../../dev/git-server/runner:/runner
     - ./entrypoint.sh:/entrypoint.sh:ro
     restart: unless-stopped
     networks:
@@ -34,21 +36,21 @@ services:
       DOCKER_TLS_CERTDIR: /certs
       DOCKER_HOST: docker-in-docker
     volumes:
-    - ../../dev/git-server/data/docker_certs:/certs
+    - ../../dev/git-server/docker_certs:/certs
     restart: unless-stopped
 
   runner:
     container_name: glk-forgejo-runner
     image: data.forgejo.org/forgejo/runner:12.7.2
     command: >-
-      forgejo-runner --config /data/config.yaml daemon
+      forgejo-runner --config /runner/config.yaml daemon
     environment:
       DOCKER_HOST: tcp://docker:2376
       DOCKER_CERT_PATH: /certs/client
       DOCKER_TLS_VERIFY: "1"
     volumes:
-    - ../../dev/git-server/data/runner:/data
-    - ../../dev/git-server/data/docker_certs:/certs
+    - ../../dev/git-server/runner:/runner
+    - ../../dev/git-server/docker_certs:/certs
     restart: unless-stopped
     depends_on:
       forgejo:

--- a/dev-setup/git-server/entrypoint.sh
+++ b/dev-setup/git-server/entrypoint.sh
@@ -27,12 +27,29 @@ create_user() {
     --password testtest \
     --email gitops@local.gardener.cloud \
     --admin"
+}
 
-  touch /data/.glk-initialisation-finished
+generate_runner_token() {
+  # Generate runner token
+  TOKEN=$(su - git -c "/usr/local/bin/forgejo forgejo-cli actions generate-secret")
+
+  # Register the runner token
+  su - git -c "/usr/local/bin/forgejo forgejo-cli actions register --secret $TOKEN --keep-labels"
+
+  # Generate UUID from token (first 16 bytes)
+  UUID=$(echo -n "$TOKEN" | head -c 16 | xxd -p -c 16 | sed -E 's/(.{8})(.{4})(.{4})(.{4})(.{12})/\1-\2-\3-\4-\5/')
+
+  # Create runner directory and copy config
+  mkdir -p /data/runner
+  cp /runner-config.yaml /data/runner/config.yaml
+
+  # Replace placeholders in config
+  sed -i "s|<TOKEN>|$TOKEN|g" /data/runner/config.yaml
+  sed -i "s|<UUID>|$UUID|g" /data/runner/config.yaml
 }
 
 if [ ! -f /data/.glk-initialisation-finished ]; then
-  create_user &
+  create_user && generate_runner_token && touch /data/.glk-initialisation-finished &
 else
   echo "glk initialisation skipped"
 fi

--- a/dev-setup/git-server/entrypoint.sh
+++ b/dev-setup/git-server/entrypoint.sh
@@ -4,15 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
-
-if [ ! -d /data/gitea/conf ]; then
-   mkdir -p /data/gitea/conf
-fi
-
-if [ ! -f /data/gitea/conf/app.ini ]; then
-   cp /app.ini.sample /data/gitea/conf/app.ini
-fi
+set -eu
 
 create_user() {
   # Wait until the server is ready
@@ -20,6 +12,11 @@ create_user() {
     echo "Waiting for Forgejo..."
     sleep 1
   done
+
+  if su - git -c "/usr/local/bin/forgejo admin user list" | grep -q 'gitops'; then
+    echo "Admin user already exists, skipping creation."
+    return
+  fi
 
   # Create default admin user
   su - git -c "/usr/local/bin/forgejo admin user create \
@@ -30,28 +27,46 @@ create_user() {
 }
 
 generate_runner_token() {
-  # Generate runner token
-  TOKEN=$(su - git -c "/usr/local/bin/forgejo forgejo-cli actions generate-secret")
-
-  # Register the runner token
-  su - git -c "/usr/local/bin/forgejo forgejo-cli actions register --secret $TOKEN --keep-labels"
-
-  # Generate UUID from token (first 16 bytes)
-  UUID=$(echo -n "$TOKEN" | head -c 16 | xxd -p -c 16 | sed -E 's/(.{8})(.{4})(.{4})(.{4})(.{12})/\1-\2-\3-\4-\5/')
-
-  # Create runner directory and copy config
+  # Create runner directory
   mkdir -p /data/runner
+
+  # Check if config already exists with configured TOKEN and UUID
+  EXISTING_TOKEN=""
+  if [ -f /data/runner/config.yaml ]; then
+    # Extract existing TOKEN from config (if not placeholders)
+    EXISTING_TOKEN=$(sed -n 's/^[[:space:]]*token:[[:space:]]*\(.*\)/\1/p' /data/runner/config.yaml || true)
+
+    # Reset if they are still placeholders
+    [ "$EXISTING_TOKEN" = "<TOKEN>" ] && EXISTING_TOKEN=""
+  fi
+
+  # Determine TOKEN to use
+  if [ -n "$EXISTING_TOKEN" ]; then
+    TOKEN="$EXISTING_TOKEN"
+    echo "Reusing existing runner token."
+  else
+    # Generate new runner token
+    TOKEN=$(su - git -c "/usr/local/bin/forgejo forgejo-cli actions generate-secret")
+
+    # Register the runner token
+    su - git -c "/usr/local/bin/forgejo forgejo-cli actions register --secret $TOKEN --keep-labels"
+  fi
+
+  UUID=$(echo -n "$TOKEN" | head -c 16 | xxd -p -c 16 | sed -E 's/(.{8})(.{4})(.{4})(.{4})(.{12})/\1-\2-\3-\4-\5/')
   cp /runner-config.yaml /data/runner/config.yaml
 
-  # Replace placeholders in config
   sed -i "s|<TOKEN>|$TOKEN|g" /data/runner/config.yaml
   sed -i "s|<UUID>|$UUID|g" /data/runner/config.yaml
 }
 
-if [ ! -f /data/.glk-initialisation-finished ]; then
-  create_user && generate_runner_token && touch /data/.glk-initialisation-finished &
-else
-  echo "glk initialisation skipped"
+if [ ! -d /data/gitea/conf ]; then
+   mkdir -p /data/gitea/conf
 fi
+
+if [ ! -f /data/gitea/conf/app.ini ]; then
+   cp /app.ini.sample /data/gitea/conf/app.ini
+fi
+
+create_user && generate_runner_token &
 
 /usr/bin/entrypoint

--- a/dev-setup/git-server/entrypoint.sh
+++ b/dev-setup/git-server/entrypoint.sh
@@ -27,14 +27,11 @@ create_user() {
 }
 
 generate_runner_token() {
-  # Create runner directory
-  mkdir -p /data/runner
-
   # Check if config already exists with configured TOKEN and UUID
   EXISTING_TOKEN=""
-  if [ -f /data/runner/config.yaml ]; then
+  if [ -f /runner/config.yaml ]; then
     # Extract existing TOKEN from config (if not placeholders)
-    EXISTING_TOKEN=$(sed -n 's/^[[:space:]]*token:[[:space:]]*\(.*\)/\1/p' /data/runner/config.yaml || true)
+    EXISTING_TOKEN=$(sed -n 's/^[[:space:]]*token:[[:space:]]*\(.*\)/\1/p' /runner/config.yaml || true)
 
     # Reset if they are still placeholders
     [ "$EXISTING_TOKEN" = "<TOKEN>" ] && EXISTING_TOKEN=""
@@ -53,10 +50,10 @@ generate_runner_token() {
   fi
 
   UUID=$(echo -n "$TOKEN" | head -c 16 | xxd -p -c 16 | sed -E 's/(.{8})(.{4})(.{4})(.{4})(.{12})/\1-\2-\3-\4-\5/')
-  cp /runner-config.yaml /data/runner/config.yaml
+  cp /runner-config.yaml /runner/config.yaml
 
-  sed -i "s|<TOKEN>|$TOKEN|g" /data/runner/config.yaml
-  sed -i "s|<UUID>|$UUID|g" /data/runner/config.yaml
+  sed -i "s|<TOKEN>|$TOKEN|g" /runner/config.yaml
+  sed -i "s|<UUID>|$UUID|g" /runner/config.yaml
 }
 
 if [ ! -d /data/gitea/conf ]; then

--- a/dev-setup/git-server/git-server-up.sh
+++ b/dev-setup/git-server/git-server-up.sh
@@ -40,7 +40,6 @@ check_local_dns_record() {
 }
 
 check_local_dns_records() {
-  check_local_dns_record $GIT_SERVER_HOSTNAME
   check_local_dns_record $REGISTRY_HOSTNAME
 }
 
@@ -86,7 +85,7 @@ for i in {1..150}; do
     break
   fi
   if (( $i % 10 == 9 )); then
-    echo "waiting for Forjo startup..."
+    echo "waiting for Forgejo startup..."
   fi
   sleep 0.1
 done

--- a/dev-setup/git-server/runner-config.yaml
+++ b/dev-setup/git-server/runner-config.yaml
@@ -1,0 +1,264 @@
+# Example configuration file, it's safe to copy this as the default config file without any modification.
+
+# You don't have to copy this file to your instance,
+# just run `forgejo-runner generate-config > config.yaml` to generate a config file.
+
+#
+# The value of level or job_level can be trace, debug, info, warn, error or fatal
+#
+log:
+  #
+  # What is displayed in the output of the runner process but not sent
+  # to the Forgejo instance.
+  #
+  level: debug
+  #
+  # What is sent to the Forgejo instance and therefore
+  # visible in the web UI for a given job.
+  #
+  job_level: info
+
+runner:
+  # Where to store the registration result.
+  file: .runner
+  # Execute how many tasks concurrently at the same time.
+  capacity: 1
+  # Extra environment variables to run jobs.
+  envs:
+    DOCKER_HOST: tcp://docker:2376
+    DOCKER_TLS_VERIFY: 1
+    DOCKER_CERT_PATH: /certs/client
+    A_TEST_ENV_NAME_1: a_test_env_value_1
+    A_TEST_ENV_NAME_2: a_test_env_value_2
+  # Extra environment variables to run jobs from a file.
+  # It will be ignored if it's empty or the file doesn't exist.
+  env_file: .env
+  # The timeout for a job to be finished.
+  # Please note that the Forgejo instance also has a timeout (3h by default) for the job.
+  # So the job could be stopped by the Forgejo instance if its timeout is shorter than this.
+  timeout: 3h
+  # The timeout for the runner to wait for running jobs to finish when
+  # shutting down because a TERM or INT signal has been received.  Any
+  # running jobs that haven't finished after this timeout will be
+  # canceled.
+  # If unset or zero, the jobs will be canceled immediately.
+  shutdown_timeout: 3h
+  # Whether skip verifying the TLS certificate of the instance.
+  insecure: false
+  # The timeout for fetching the job from the Forgejo instance.
+  fetch_timeout: 30s
+  # The interval for fetching the job from the Forgejo instance.
+  fetch_interval: 2s
+  # The interval for reporting the job status and logs to the Forgejo instance.
+  report_interval: 1s
+  # At the end of a job, retry configuration for sending logs to remote.
+  # report_retry:
+  #   # Maximum number of retry attempts.
+  #   max_retries: 10
+  #   # Initial delay between retries.  Delay between retries doubles up to `max_delay`.
+  #   initial_delay: 100ms
+  #   # Maximum delay between retries, defaults to 0, 0 is treated as no maximum.
+  #   max_delay: 0
+  # The labels of a runner are used to determine which jobs the runner can run and how to run them.
+  # Like: ["macos-arm64:host", "ubuntu-latest:docker://node:20-bookworm", "ubuntu-22.04:docker://node:20-bookworm"]
+  # If it's empty when registering, it will ask for inputting labels.
+  # If it's empty when executing the `daemon`, it will use labels in the `.runner` file.
+  labels: ["d","docker:docker://codeberg.org/oranki/forgejo-runner:3.5.1"]
+
+cache:
+  #
+  # When enabled, workflows will be given the ACTIONS_CACHE_URL environment variable
+  # used by the https://code.forgejo.org/actions/cache action. The server at this
+  # URL must implement a compliant REST API, and it must also be reachable from
+  # the container or host running the workflows.
+  #
+  # See also https://forgejo.org/docs/next/user/actions/advanced-features/#cache
+  #
+  # When it is not enabled, none of the following options apply.
+  #
+  # It works as follows:
+  #
+  # - the workflow is given a one-time use ACTIONS_CACHE_URL
+  # - a cache proxy listens to ACTIONS_CACHE_URL
+  # - the cache proxy securely communicates with the cache server using
+  #   a shared secret
+  #
+  enabled: true
+  #
+  #######################################################################
+  #
+  # Only used for the internal cache server.
+  #
+  # If external_server is not set, the Forgejo runner will spawn a
+  # cache server that will be used by the cache proxy.
+  #
+  #######################################################################
+  #
+  # The port being bound by the internal cache server.
+  # 0 means to use a random available port.
+  #
+  port: 0
+  #
+  # The directory to store the cache data.
+  #
+  # If empty, the cache data will be stored in $HOME/.cache/actcache.
+  #
+  dir: ""
+  #
+  #######################################################################
+  #
+  # Only used for the external cache server.
+  #
+  # If external_server is set, the internal cache server is not
+  # spawned.
+  #
+  #######################################################################
+  #
+  # The URL of the cache server. The URL should generally end with
+  # "/". The cache proxy will forward requests to the external
+  # server. The requests are authenticated with the "secret" that is
+  # shared with the external server.
+  #
+  external_server: ""
+  #
+  # The shared cache secret used to secure the communications between
+  # the cache proxy and the cache server.
+  #
+  # If empty, it will be generated to a new secret automatically when
+  # the server starts, and it will stay the same until it restarts.
+  #
+  # `secret` and `secret_url` are mutually exclusive.
+  #
+  secret: ""
+  #
+  # The secret for securing the cache can alternatively be loaded from a URL.
+  # Currently, only file URLs can be resolved. Example:
+  # `file:/path/to/secret.txt`.
+  #
+  # `secret_url` supports a single placeholder: `$CREDENTIALS_DIRECTORY`. If
+  # the environment variable `CREDENTIALS_DIRECTORY` exists, the placeholder is
+  # replaced with the value of `CREDENTIALS_DIRECTORY`. Otherwise, it is
+  # retained.
+  #
+  #  Example: file:$CREDENTIALS_DIRECTORY/secret.txt
+  #
+  # `secret` and `secret_url` are mutually exclusive.
+  #
+  secret_url: ""
+  #
+  #######################################################################
+  #
+  # Common to the internal and external cache server
+  #
+  #######################################################################
+  #
+  # The IP or hostname (195.84.20.30 or example.com) to use when constructing
+  # ACTIONS_CACHE_URL which is the URL of the cache proxy.
+  #
+  # If empty, it will be detected automatically.
+  #
+  # It may be impossible to figure out the host automatically if the containers
+  # or host running the workflows reside on a different network than the Forgejo
+  # runner. For example, if the Docker server used to create containers is not
+  # running on the same host as the Forgejo runner.
+  # In that case you can specify which IP or hostname to use to reach the
+  # internal cache server created by the Forgejo runner.
+  #
+  host: ""
+  #
+  # The port bound by the internal cache proxy.
+  # 0 means to use a random available port.
+  #
+  proxy_port: 0
+  #
+  # Overrides the ACTIONS_CACHE_URL variable passed to workflow
+  # containers. The URL should generally not end with "/". This should only
+  # be used if the runner host is not reachable from the workflow containers
+  # and requires further setup.
+  #
+  actions_cache_url_override: ""
+
+container:
+  # Specifies the network to which the container will connect.
+  # Could be `host`, `bridge` or the name of a custom network.
+  # If it's empty, create a network automatically.
+  network: host
+  # Whether to create networks with IPv6 enabled. Requires the Docker daemon to be set up accordingly.
+  # Only takes effect if "network" is set to "".
+  enable_ipv6: false
+  # Whether to use privileged mode or not when launching task containers (privileged mode is required for Docker-in-Docker).
+  privileged: false
+  # And other options to be used when the container is started (e.g., --volume /etc/ssl/certs:/etc/ssl/certs:ro).
+  options: -v /certs/client:/certs/client
+  # The parent directory of a job's working directory.
+  # If it's empty, /workspace will be used.
+  workdir_parent:
+  # Volumes (including bind mounts) can be mounted to containers. Glob syntax is supported, see https://github.com/gobwas/glob
+  # You can specify multiple volumes. If the sequence is empty, no volumes can be mounted.
+  # For example, if you only allow containers to mount the `data` volume and all the JSON files in `/src`, you should change the config to:
+  # valid_volumes:
+  #   - data
+  #   - /etc/ssl/certs
+  # If you want to allow any volume, please use the following configuration:
+  # valid_volumes:
+  #   - '**'
+  valid_volumes:
+  - /certs/client
+  # Overrides the docker host set by the DOCKER_HOST environment variable, and mounts on the job container.
+  # If "-" or "", no docker host will be mounted in the job container
+  # If "automount", an available docker host will automatically be found and mounted in the job container (e.g., /var/run/docker.sock).
+  # If it's a url, the specified docker host will be mounted in the job container
+  # Example urls: unix:///run/docker.socket or ssh://user@host
+  # The specified socket is mounted within the job container at /var/run/docker.sock
+  docker_host: "-"
+  # Pull docker image(s) even if already present
+  force_pull: false
+  # Rebuild local docker image(s) even if already present
+  force_rebuild: false
+
+host:
+  # The parent directory of a job's working directory.
+  # If it's empty, $HOME/.cache/act/ will be used.
+  workdir_parent:
+
+server:
+  # A map of connections to one or more Forgejo instances. Example:
+  #
+  # ```
+  # connections:
+  #   example:
+  #     url: https://example.com/
+  #     uuid: c9e50be9-a7c3-4aee-ba35-624c4ff8c519
+  #     token: 6634bb58be0db23cc013a2e72dd1828ae0257cf
+  #     fetch_interval: 30s
+  #   codeberg:
+  #     url: https://codeberg.org/
+  #     uuid: f543b661-cb02-4ba2-9820-108df62808b5
+  #     token_url: file:$CREDENTIALS_DIRECTORY/token.txt
+  #     labels:
+  #       - debian:docker://docker.io/library/node:lts-trixie
+  # ```
+  #
+  # The map's keys (`example`, and `codeberg` above) serve as the connections'
+  # names.
+  #
+  # The runner token can either be specified inline using `token` or be loaded
+  # from a file using `token_url`. The methods are mutually exclusive.
+  # `token_url` supports a single placeholder: `$CREDENTIALS_DIRECTORY`. If the
+  # environment variable `CREDENTIALS_DIRECTORY` exists, the placeholder is
+  # replaced with the value of `CREDENTIALS_DIRECTORY`. Otherwise, it is
+  # retained.
+  #
+  # Labels defined on a connection are limited to that particular connection.
+  # If a connection defines no labels, the labels declared by `runner.labels`
+  # are used instead.
+  #
+  # `fetch_interval` specifies how often Forgejo Runner should ask Forgejo for
+  # pending jobs. If `fetch_interval` is not defined on a connection,
+  # `runner.fetch_interval` is used. Note that Forgejo Runner might enforce a
+  # minimum value for certain instances like Codeberg.
+  connections:
+    forgejo:
+      url: http://git.local.gardener.cloud:6080/
+      uuid: <UUID>
+      token: <TOKEN>

--- a/dev-setup/infra/bind/db.local.gardener.cloud
+++ b/dev-setup/infra/bind/db.local.gardener.cloud
@@ -22,4 +22,5 @@ ns      IN      AAAA    fd00:ff::54
 registry        IN      NS      docker-dns.local.gardener.cloud.
 glk-registry    IN      NS      docker-dns.local.gardener.cloud.
 registry-cache  IN      NS      docker-dns.local.gardener.cloud.
+git             IN      NS      docker-dns.local.gardener.cloud.
 docker-dns      IN      A       127.0.0.11

--- a/dev-setup/infra/bind/db.local.gardener.cloud
+++ b/dev-setup/infra/bind/db.local.gardener.cloud
@@ -22,5 +22,5 @@ ns      IN      AAAA    fd00:ff::54
 registry        IN      NS      docker-dns.local.gardener.cloud.
 glk-registry    IN      NS      docker-dns.local.gardener.cloud.
 registry-cache  IN      NS      docker-dns.local.gardener.cloud.
-git             IN      NS      docker-dns.local.gardener.cloud.
+git             IN      A       127.0.0.1
 docker-dns      IN      A       127.0.0.11

--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -10,11 +10,9 @@ set -o errexit
 
 glk_ensure_local_gardener_cloud_hosts() {
   if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-    echo "> Adding local.gardener.cloud entries to /etc/hosts..."
+    echo "> Adding registry entries to /etc/hosts..."
     printf "\n127.0.0.1 glk-registry.local.gardener.cloud\n" >> /etc/hosts
     printf "\n::1 glk-registry.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n127.0.0.1 git.local.gardener.cloud\n" >> /etc/hosts
-    printf "\n::1 git.local.gardener.cloud\n" >> /etc/hosts
     echo "> Content of '/etc/hosts' after adding local.gardener.cloud entries:\n$(cat /etc/hosts)"
   fi
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity testing
/kind enhancement

**What this PR does / why we need it**:
Adds a runner for the local setup to allow running [Forejo Actions](https://forgejo.org/docs/next/user/actions/reference/).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @LucaBernstein

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The local setup now has a Forgejo runner to allow running [Forejo Actions](https://forgejo.org/docs/next/user/actions/reference/).
```
