### PR TITLE
Add reusable GitHub Actions

### DIFF
--- a/.github/actions/glk/action.yaml
+++ b/.github/actions/glk/action.yaml
@@ -1,0 +1,64 @@
+name: GLK
+description: Run gardener-landscape-kit commands using the container image version from components.yaml
+
+inputs:
+  components-file:
+    description: Path to the GLK components.yaml
+    required: true
+  commands:
+    description: |
+      GLK commands to execute, one per line. If not provided, runs default commands.
+      Lines starting with # are treated as comments and ignored.
+      Example:
+        generate base -c landscape/glk.yaml ./base
+        generate landscape -c landscape/glk.yaml .
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+  - name: Extract GLK version from components.yaml
+    id: glk-version
+    shell: bash
+    run: |
+      version=$(grep -A1 'name: github.com/gardener/gardener-landscape-kit' "${{ inputs.components-file }}" | grep 'version:' | awk '{print $2}')
+      echo "version=${version}" >> "$GITHUB_OUTPUT"
+      echo "GLK version: ${version}"
+
+  - name: Run GLK resolve and generate
+    shell: bash
+    env:
+      GLK_IMAGE: europe-docker.pkg.dev/gardener-project/public/gardener/gardener-landscape-kit:${{ steps.glk-version.outputs.version }}
+      GLK_COMMANDS: ${{ inputs.commands }}
+    run: |
+      set -euo pipefail
+      # GLK wrapper function
+      glk() {
+        docker run --rm --user "$(id -u):$(id -g)" -v "${{ github.workspace }}:/workspace" -w /workspace "${GLK_IMAGE}" "$@"
+      }
+      
+      # GLK commands
+      echo "Running GLK commands"
+      
+      command_number=0
+      while IFS= read -r line; do
+        # Skip empty lines and comments
+        if [ -n "$line" ] && [[ ! "$line" =~ ^[[:space:]]*# ]]; then
+          command_number=$((command_number + 1))
+      
+          # Strip 'glk' prefix if present
+          if [[ "$line" =~ ^glk[[:space:]]+ ]]; then
+            line="${line#glk }"
+          fi
+      
+          echo "[$command_number] Executing: glk ${line}"
+          eval "glk ${line}"
+        fi
+      done <<< "${GLK_COMMANDS}"
+      
+      if [ $command_number -eq 0 ]; then
+        echo "Warning: No valid commands found in input"
+      else
+        echo "Successfully executed $command_number command(s)"
+      fi

--- a/.github/workflows/glk.yaml
+++ b/.github/workflows/glk.yaml
@@ -1,0 +1,61 @@
+# Reusable workflow for running GLK commands in a pull request context.
+# It checks out the PR branch, runs specified GLK commands, and commits any changes back to the PR branch.
+name: GLK PR Workflow
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: 'Runner to use for the job'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      glk-commands:
+        description: 'GLK commands to execute (newline-separated)'
+        required: true
+        type: string
+      components-file:
+        description: 'Path to components.yaml file'
+        required: false
+        type: string
+      commit-message:
+        description: 'Commit message for generated changes'
+        required: false
+        type: string
+        default: 'chore: run gardener-landscape-kit'
+
+jobs:
+  glk:
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout PR branch
+      uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        ref: ${{ github.event.pull_request.head.ref || github.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
+    - name: Set up Git
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: GLK Commands
+      uses: ./.github/actions/glk
+      with:
+        components-file: ${{ inputs.components-file }}
+        commands: ${{ inputs.glk-commands }}
+
+    - name: Commit and push changes
+      run: |
+        git add .
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "${{ inputs.commit-message }}"
+          git push origin HEAD:${{ github.event.pull_request.head.ref || github.ref_name }}
+        fi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
Adds reusable GitHub Actions, enabling the integration of GLK in pull requests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Directory [`.github`](https://github.com/gardener/gardener-landscape-kit/tree/main/.github) now contains a reusable GLK GitHub Action and Workflow. They enable the integration and automated execution of GLK commands in the scope of pull requests or similar repository events.
```
