### PR TITLE
Fix file name for custom component in `hack/resolve-public-ocm-component.sh`

### DIFF
--- a/hack/resolve-public-ocm-component.sh
+++ b/hack/resolve-public-ocm-component.sh
@@ -56,8 +56,8 @@ ocm:
   ignoreMissingComponents: true
 EOF
 
-# Fake component as custom OCM component, to be resolved by the landscapekit and written to the components vector file.
-echo $componentName > "$tmp_dir/ocm-component-name"
+# Fake component as custom component, to be resolved by the landscapekit and written to the components vector file.
+echo $componentName > "$tmp_dir/component-name"
 
 go run ./cmd/gardener-landscape-kit resolve ocm -c "$tmp_dir/landscapekitconfiguration.yaml" -d "$tmp_dir" > /dev/null
 

--- a/pkg/ocm/resolve.go
+++ b/pkg/ocm/resolve.go
@@ -232,11 +232,11 @@ func (r *ocmComponentsResolver) findCustomComponents() (sets.Set[string], error)
 		}
 		content, err := os.ReadFile(path) // #nosec: G304,G122 -- safe, as it's reading within the landscape directory
 		if err != nil {
-			return fmt.Errorf("failed to read custom OCM component name file %s: %w", path, err)
+			return fmt.Errorf("failed to read custom component name file %s: %w", path, err)
 		}
 		name := strings.TrimSpace(string(content))
 		customComponents.Insert(name)
-		r.log.Info("Found custom OCM component", "name", name, "file", path)
+		r.log.Info("Found custom component", "name", name, "file", path)
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("failed to walk landscape directory %s: %w", r.landscapeDir, err)


### PR DESCRIPTION
… 

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Fix file name for custom component in `hack/resolve-public-ocm-component.sh` and drop OCM from messages for custom components

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
