### PR TITLE
Add `shoot-traefik` extension

### DIFF
--- a/componentvector/components.go
+++ b/componentvector/components.go
@@ -37,6 +37,8 @@ const (
 	NameGardenerGardenerExtensionShootNetworkingProblemdetector = "github.com/gardener/gardener-extension-shoot-networking-problemdetector"
 	// NameGardenerGardenerExtensionShootOidcService is a constant for a component in the component vector with name 'github.com/gardener/gardener-extension-shoot-oidc-service'.
 	NameGardenerGardenerExtensionShootOidcService = "github.com/gardener/gardener-extension-shoot-oidc-service"
+	// NameGardenerGardenerExtensionShootTraefik is a constant for a component in the component vector with name 'github.com/gardener/gardener-extension-shoot-traefik'.
+	NameGardenerGardenerExtensionShootTraefik = "github.com/gardener/gardener-extension-shoot-traefik"
 	// NameGardenerGardenerLandscapeKit is a constant for a component in the component vector with name 'github.com/gardener/gardener-landscape-kit'.
 	NameGardenerGardenerLandscapeKit = "github.com/gardener/gardener-landscape-kit"
 )

--- a/componentvector/components.yaml
+++ b/componentvector/components.yaml
@@ -137,6 +137,13 @@ components:
     shootOidcService:
       helmChart:
         repository: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-oidc-service
+- name: github.com/gardener/gardener-extension-shoot-traefik
+  sourceRepository: https://github.com/gardener/gardener-extension-shoot-traefik
+  version: v0.4.0
+  resources:
+    shootTraefik:
+      helmChart:
+        repository: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-traefik
 - name: github.com/gardener/gardener-extension-shoot-networking-problemdetector
   sourceRepository: https://github.com/gardener/gardener-extension-shoot-networking-problemdetector
   version: v0.32.1

--- a/pkg/components/gardener-extensions/shoot-traefik/component.go
+++ b/pkg/components/gardener-extensions/shoot-traefik/component.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package traefik
+
+import (
+	"embed"
+	"path"
+
+	"github.com/gardener/gardener/pkg/utils"
+
+	"github.com/gardener/gardener-landscape-kit/componentvector"
+	"github.com/gardener/gardener-landscape-kit/pkg/components"
+	"github.com/gardener/gardener-landscape-kit/pkg/utils/files"
+)
+
+const (
+	// ComponentDirectory is the garden component directory within the base components directory.
+	ComponentDirectory = "gardener-extensions/shoot-traefik"
+)
+
+var (
+	// baseTemplateDir is the directory where the base templates are stored.
+	baseTemplateDir = "templates/base"
+	//go:embed templates/base
+	baseTemplates embed.FS
+
+	// landscapeTemplateDir is the directory where the landscape templates are stored.
+	landscapeTemplateDir = "templates/landscape"
+	//go:embed templates/landscape
+	landscapeTemplates embed.FS
+)
+
+type component struct{}
+
+// NewComponent creates a new garden component.
+func NewComponent() components.Interface {
+	return &component{}
+}
+
+// Name returns the component name.
+func (c *component) Name() string {
+	return "shoot-traefik"
+}
+
+// GenerateBase generates the component base directory.
+func (c *component) GenerateBase(options components.Options) error {
+	for _, op := range []func(components.Options) error{
+		writeBaseTemplateFiles,
+	} {
+		if err := op(options); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GenerateLandscape generates the component landscape directory.
+func (c *component) GenerateLandscape(options components.LandscapeOptions) error {
+	for _, op := range []func(components.LandscapeOptions) error{
+		writeLandscapeTemplateFiles,
+	} {
+		if err := op(options); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getTemplateValues(opts components.Options) (map[string]any, error) {
+	return components.GetComponentVectorTemplateValues(opts, componentvector.NameGardenerGardenerExtensionShootTraefik)
+}
+
+func writeBaseTemplateFiles(opts components.Options) error {
+	objects, err := files.RenderTemplateFiles(baseTemplates, baseTemplateDir, nil)
+	if err != nil {
+		return err
+	}
+
+	return files.WriteObjectsToFilesystem(objects, opts.GetTargetPath(), path.Join(components.DirName, ComponentDirectory), opts.GetFilesystem(), opts.GetMergeMode())
+}
+
+func writeLandscapeTemplateFiles(opts components.LandscapeOptions) error {
+	var (
+		relativeComponentPath = path.Join(components.DirName, ComponentDirectory)
+		relativeRepoRoot      = files.CalculatePathToComponentBase(opts.GetRelativeLandscapePath(), relativeComponentPath)
+	)
+
+	renderValue, err := getTemplateValues(opts)
+	if err != nil {
+		return err
+	}
+	values := utils.MergeMaps(renderValue, map[string]any{
+		"relativePathToBaseComponent": path.Join(relativeRepoRoot, opts.GetRelativeBasePath(), relativeComponentPath),
+		"landscapeComponentPath":      path.Join(opts.GetRelativeLandscapePath(), relativeComponentPath),
+	})
+	objects, err := files.RenderTemplateFiles(landscapeTemplates, landscapeTemplateDir, values)
+	if err != nil {
+		return err
+	}
+
+	return files.WriteObjectsToFilesystem(objects, opts.GetTargetPath(), path.Join(components.DirName, ComponentDirectory), opts.GetFilesystem(), opts.GetMergeMode())
+}

--- a/pkg/components/gardener-extensions/shoot-traefik/component_test.go
+++ b/pkg/components/gardener-extensions/shoot-traefik/component_test.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package traefik_test
+
+import (
+	"os"
+
+	"github.com/gardener/gardener/pkg/utils/imagevector"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	"github.com/gardener/gardener-landscape-kit/pkg/apis/config/v1alpha1"
+	"github.com/gardener/gardener-landscape-kit/pkg/cmd"
+	generateoptions "github.com/gardener/gardener-landscape-kit/pkg/cmd/generate/options"
+	"github.com/gardener/gardener-landscape-kit/pkg/components"
+	. "github.com/gardener/gardener-landscape-kit/pkg/components/gardener-extensions/shoot-traefik"
+	"github.com/gardener/gardener-landscape-kit/pkg/utils/componentvector"
+	"github.com/gardener/gardener-landscape-kit/pkg/utils/test"
+)
+
+var _ = Describe("Component Generation", func() {
+	var (
+		fs           afero.Afero
+		cmdOpts      *cmd.Options
+		generateOpts *generateoptions.Options
+	)
+
+	BeforeEach(func() {
+		fs = afero.Afero{Fs: afero.NewMemMapFs()}
+		cmdOpts = &cmd.Options{Log: logr.Discard()}
+		generateOpts = &generateoptions.Options{
+			TargetDirPath: "/repo/baseDir",
+			Options:       cmdOpts,
+			Config:        &v1alpha1.LandscapeKitConfiguration{},
+		}
+		v1alpha1.SetObjectDefaults_LandscapeKitConfiguration(generateOpts.Config)
+	})
+
+	Describe("#GenerateBase", func() {
+		var opts components.Options
+
+		BeforeEach(func() {
+			var err error
+			opts, err = components.NewOptions(generateOpts, fs)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should generate the component base", func() {
+			component := NewComponent()
+			Expect(component.GenerateBase(opts)).To(Succeed())
+
+			content, err := fs.ReadFile("/repo/baseDir/components/gardener-extensions/shoot-traefik/extension.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("apiVersion: operator.gardener.cloud/v1alpha1"))
+			Expect(string(content)).To(ContainSubstring("kind: Extension"))
+
+			content, err = fs.ReadFile("/repo/baseDir/components/gardener-extensions/shoot-traefik/kustomization.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("- extension.yaml"))
+		})
+	})
+
+	Describe("#GenerateLandscape", func() {
+		BeforeEach(func() {
+			generateOpts.TargetDirPath = "/repo/landscapeDir"
+			generateOpts.Config = &v1alpha1.LandscapeKitConfiguration{
+				Git: &v1alpha1.GitRepository{Paths: v1alpha1.PathConfiguration{Landscape: "./landscapeDir", Base: "./baseDir"}},
+			}
+			v1alpha1.SetObjectDefaults_LandscapeKitConfiguration(generateOpts.Config)
+		})
+
+		It("should generate only the flux kustomization into the landscape dir", func() {
+			component := NewComponent()
+			landscapeOpts, err := components.NewLandscapeOptions(generateOpts, fs)
+			Expect(component.GenerateLandscape(landscapeOpts)).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
+
+			exists, err := fs.DirExists("/repo/baseDir")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+
+			content, err := fs.ReadFile("/repo/landscapeDir/components/gardener-extensions/shoot-traefik/flux-kustomization.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("path: landscapeDir/components/gardener-extensions/shoot-traefik"))
+
+			content, err = fs.ReadFile("/repo/landscapeDir/components/gardener-extensions/shoot-traefik/kustomization.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("- ../../../../baseDir/components/gardener-extensions/shoot-traefik"))
+		})
+
+		DescribeTable("should generate correct kustomized build output",
+			func(build test.BuildComponentVectorFn, expectedFile string) {
+				component := NewComponent()
+				Expect(test.CreateComponentsVectorFile(fs, build)).To(Succeed())
+				result, err := test.KustomizeComponent(fs, component, "components/gardener-extensions/shoot-traefik")
+				Expect(err).ToNot(HaveOccurred())
+				expected, err := os.ReadFile(expectedFile)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(result)).To(Equal(string(expected)))
+			},
+			Entry("with plain component vector without OCM resources",
+				test.NewComponentVectorFactoryBuilder("github.com/gardener/gardener-extension-shoot-traefik", "v1.2.3").WithDefaultResources().Build(),
+				"testdata/expected-kustomize-plain.yaml"),
+			Entry("with OCM component vector including helm charts and OCI images",
+				test.NewComponentVectorFactoryBuilder("github.com/gardener/gardener-extension-shoot-traefik", "v1.2.3").
+					WithImageVectorOverwrite(componentvector.ImageVectorOverwrite{
+						Images: []imagevector.ImageSource{
+							{
+								Name: "component1",
+								Ref:  new("test.repo/path/component1:v1.2.3"),
+							},
+						},
+					}).
+					WithResourcesYAML(`
+shootTraefik:
+  helmChart:
+    ref: test-repo/path/charts/gardener/extensions/shoot-traefik:v1.2.3
+    imageMap:
+      gardenerExtensionShootTraefik:
+        image:
+          repository: test-repo/path/gardener/extensions/shoot-traefik
+          tag: v1.2.3
+`).Build(),
+				"testdata/expected-kustomize-ocm.yaml"),
+		)
+	})
+})

--- a/pkg/components/gardener-extensions/shoot-traefik/shoot_traefik_suite_test.go
+++ b/pkg/components/gardener-extensions/shoot-traefik/shoot_traefik_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package traefik_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestShootTraefik(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Components Shoot Traefik Suite")
+}

--- a/pkg/components/gardener-extensions/shoot-traefik/templates/base/extension.yaml
+++ b/pkg/components/gardener-extensions/shoot-traefik/templates/base/extension.yaml
@@ -1,0 +1,13 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  annotations:
+    security.gardener.cloud/pod-security-enforce: baseline
+  name: shoot-traefik
+spec:
+  resources:
+  - clusterCompatibility:
+    - shoot
+    kind: Extension
+    type: shoot-traefik
+    workerlessSupported: false

--- a/pkg/components/gardener-extensions/shoot-traefik/templates/base/kustomization.yaml
+++ b/pkg/components/gardener-extensions/shoot-traefik/templates/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- extension.yaml

--- a/pkg/components/gardener-extensions/shoot-traefik/templates/landscape/extension.yaml
+++ b/pkg/components/gardener-extensions/shoot-traefik/templates/landscape/extension.yaml
@@ -1,0 +1,30 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: shoot-traefik
+spec:
+  deployment:
+    extension:
+      helm:
+        ociRepository:
+          ref: {{ .resources.shootTraefik.helmChart.ref }}
+      {{- if (or .resources.shootTraefik.helmChart.imageMap .imageVectorOverwrite) }}
+      runtimeClusterValues:
+        {{- if .resources.shootTraefik.helmChart.imageMap }}
+{{ toIndentYAML 2 .resources.shootTraefik.helmChart.imageMap.gardenerExtensionShootTraefik | indent 8 }}
+        {{- end }}
+        {{- if .imageVectorOverwrite }}
+        imageVectorOverwrite:
+{{ indent 10 .imageVectorOverwrite }}
+        {{- end }}
+      {{- end }}
+      {{- if (or .resources.shootTraefik.helmChart.imageMap .imageVectorOverwrite) }}
+      values:
+        {{- if .resources.shootTraefik.helmChart.imageMap }}
+{{ toIndentYAML 2 .resources.shootTraefik.helmChart.imageMap.gardenerExtensionShootTraefik | indent 8 }}
+        {{- end }}
+        {{- if .imageVectorOverwrite }}
+        imageVectorOverwrite:
+{{ indent 10 .imageVectorOverwrite }}
+        {{- end }}
+      {{- end }}

--- a/pkg/components/gardener-extensions/shoot-traefik/templates/landscape/flux-kustomization.yaml
+++ b/pkg/components/gardener-extensions/shoot-traefik/templates/landscape/flux-kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: extension-shoot-traefik
+  namespace: garden
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: {{ .landscapeComponentPath }}
+  prune: true
+  dependsOn:
+  - name: gardener-operator
+    namespace: garden
+  interval: 30m
+  timeout: 10m
+  retryInterval: 30s
+  wait: true
+  healthCheckExprs:
+  - apiVersion: operator.gardener.cloud/v1alpha1
+    kind: Extension
+    current: "status.conditions.filter(e, e.type == 'Installed').all(e, e.status == 'True')"

--- a/pkg/components/gardener-extensions/shoot-traefik/templates/landscape/kustomization.yaml
+++ b/pkg/components/gardener-extensions/shoot-traefik/templates/landscape/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- {{ .relativePathToBaseComponent }}
+patches:
+- path: extension.yaml

--- a/pkg/components/gardener-extensions/shoot-traefik/testdata/expected-kustomize-ocm.yaml
+++ b/pkg/components/gardener-extensions/shoot-traefik/testdata/expected-kustomize-ocm.yaml
@@ -1,0 +1,34 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  annotations:
+    security.gardener.cloud/pod-security-enforce: baseline
+  name: shoot-traefik
+spec:
+  deployment:
+    extension:
+      helm:
+        ociRepository:
+          ref: test-repo/path/charts/gardener/extensions/shoot-traefik:v1.2.3
+      runtimeClusterValues:
+        image:
+          repository: test-repo/path/gardener/extensions/shoot-traefik
+          tag: v1.2.3
+        imageVectorOverwrite:
+          images:
+          - name: component1
+            ref: test.repo/path/component1:v1.2.3
+      values:
+        image:
+          repository: test-repo/path/gardener/extensions/shoot-traefik
+          tag: v1.2.3
+        imageVectorOverwrite:
+          images:
+          - name: component1
+            ref: test.repo/path/component1:v1.2.3
+  resources:
+  - clusterCompatibility:
+    - shoot
+    kind: Extension
+    type: shoot-traefik
+    workerlessSupported: false

--- a/pkg/components/gardener-extensions/shoot-traefik/testdata/expected-kustomize-plain.yaml
+++ b/pkg/components/gardener-extensions/shoot-traefik/testdata/expected-kustomize-plain.yaml
@@ -1,0 +1,18 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  annotations:
+    security.gardener.cloud/pod-security-enforce: baseline
+  name: shoot-traefik
+spec:
+  deployment:
+    extension:
+      helm:
+        ociRepository:
+          ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-traefik:v1.2.3
+  resources:
+  - clusterCompatibility:
+    - shoot
+    kind: Extension
+    type: shoot-traefik
+    workerlessSupported: false

--- a/pkg/registry/register.go
+++ b/pkg/registry/register.go
@@ -29,6 +29,7 @@ import (
 	dnsservice "github.com/gardener/gardener-landscape-kit/pkg/components/gardener-extensions/shoot-dns-service"
 	networkingproblemdetector "github.com/gardener/gardener-landscape-kit/pkg/components/gardener-extensions/shoot-networking-problemdetector"
 	oidcservice "github.com/gardener/gardener-landscape-kit/pkg/components/gardener-extensions/shoot-oidc-service"
+	traefik "github.com/gardener/gardener-landscape-kit/pkg/components/gardener-extensions/shoot-traefik"
 	"github.com/gardener/gardener-landscape-kit/pkg/components/gardener/garden"
 	"github.com/gardener/gardener-landscape-kit/pkg/components/gardener/operator"
 	virtualgardenaccess "github.com/gardener/gardener-landscape-kit/pkg/components/gardener/virtual-garden-access"
@@ -52,6 +53,7 @@ var ComponentList = []func() components.Interface{
 	certservice.NewComponent,
 	dnsservice.NewComponent,
 	oidcservice.NewComponent,
+	traefik.NewComponent,
 	networkingproblemdetector.NewComponent,
 	gvisor.NewComponent,
 	virtualgardenaccess.NewComponent,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Adds support for https://github.com/gardener/gardener-extension-shoot-traefik.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
FYI @ScheererJ @DockToFuture @domdom82

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A new component [`shoot-traefik`](https://github.com/gardener/gardener-extension-shoot-traefik) has been added to GLK.
```
