### PR TITLE
Support extra component references

### DIFF
--- a/hack/tools/ocm-testdata-generator/config.go
+++ b/hack/tools/ocm-testdata-generator/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	ExternalResources []ExternalResource `json:"externalResources"`
 	// Components is a list of additional components to be added to the root component.
 	Components []Component `json:"components"`
+	// ExtraComponentReferences is a list of extra component references to be added to the root component.
+	ExtraComponentReferences []ExtraComponentRef `json:"extraComponentReferences"`
 	// TargetRepositoryURL is the URL of the target repository containing the overwrites.
 	TargetRepositoryURL string `json:"targetRepositoryURL"`
 }
@@ -29,6 +31,12 @@ type Component struct {
 	Name          string `json:"name"`
 	Version       string `json:"version"`
 	ComponentName string `json:"componentName"`
+}
+
+// ExtraComponentRef represents an extra component reference to be included in the configuration.
+type ExtraComponentRef struct {
+	ComponentName string `json:"componentName"`
+	Version       string `json:"version"`
 }
 
 // ExternalResource represents an external resource to be included in the configuration.

--- a/hack/tools/ocm-testdata-generator/generate.go
+++ b/hack/tools/ocm-testdata-generator/generate.go
@@ -53,8 +53,19 @@ type OCMComponent struct {
 
 // OCMLabel represents a label in the OCM component descriptor.
 type OCMLabel struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name  string          `json:"name"`
+	Value json.RawMessage `json:"value"`
+}
+
+// OCMExtraComponentReference represents an extra component reference to be added to the root component.
+type OCMExtraComponentReference struct {
+	ComponentReference OCMExtraComponentReferenceData `json:"component_reference"`
+}
+
+// OCMExtraComponentReferenceData contains the name and version of an extra component reference.
+type OCMExtraComponentReferenceData struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 // NewGenerator creates a new generator for OCM component descriptors test data with the given config.
@@ -79,6 +90,13 @@ func (g *generator) Generate(targetDir string) error {
 	}
 
 	toBeProcessed := slices.Clone(g.config.Components)
+	for _, component := range g.config.ExtraComponentReferences {
+		toBeProcessed = append(toBeProcessed, Component{
+			Name:          component.ComponentName,
+			Version:       component.Version,
+			ComponentName: component.ComponentName,
+		})
+	}
 	processedComponents := set.New[components.ComponentReference]()
 	for len(toBeProcessed) > 0 {
 		current := toBeProcessed[0]
@@ -180,13 +198,33 @@ func (g *generator) generateKubernetesRootComponent(targetDir string) error {
 			Labels: []OCMLabel{
 				{
 					Name:  components.LabelImageVectorApplication,
-					Value: "kubernetes",
+					Value: json.RawMessage(`"kubernetes"`),
 				},
 			},
 			Provider:            "test-resources",
 			Resources:           resourceSlice,
 			ComponentReferences: componentSlice,
 		},
+	}
+
+	if len(g.config.ExtraComponentReferences) > 0 {
+		var refs []OCMExtraComponentReference
+		for _, ref := range g.config.ExtraComponentReferences {
+			refs = append(refs, OCMExtraComponentReference{
+				ComponentReference: OCMExtraComponentReferenceData{
+					Name:    ref.ComponentName,
+					Version: ref.Version,
+				},
+			})
+		}
+		value, err := json.Marshal(refs)
+		if err != nil {
+			return fmt.Errorf("failed to marshal extra component references: %w", err)
+		}
+		ocm.Component.Labels = append(ocm.Component.Labels, OCMLabel{
+			Name:  components.LabelExtraComponentReferences,
+			Value: json.RawMessage(value),
+		})
 	}
 
 	data, err := json.MarshalIndent(ocm, "", "  ")

--- a/pkg/ocm/components/components.go
+++ b/pkg/ocm/components/components.go
@@ -285,6 +285,20 @@ func (c *Components) AddComponentDependencies(descriptor *descriptorruntime.Desc
 			dependency.ImageVector = append(dependency.ImageVector, *imageSource)
 		}
 	}
+	extraRefs, err := extraReferences(descriptor)
+	if err != nil {
+		return nil, err
+	}
+	for _, ref := range extraRefs {
+		cref := ComponentReference(fmt.Sprintf("%s:%s", ref.ComponentReference.Name, ref.ComponentReference.Version))
+		dependency := dependencies[cref]
+		if dependency == nil {
+			dependency = &Dependency{
+				ComponentReference: cref,
+			}
+			dependencies[cref] = dependency
+		}
+	}
 
 	var newComponents []ComponentReference
 	for cref, dep := range dependencies {
@@ -853,4 +867,30 @@ func dashToCamelCaseForMapKeys(m map[string]*utilscomponentvector.ResourceData) 
 		result[newKey] = *value
 	}
 	return result
+}
+
+type extraComponentReference struct {
+	ComponentReference struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"component_reference"`
+}
+
+// extraReferences extracts extra component references from the descriptor's labels.
+func extraReferences(descriptor *descriptorruntime.Descriptor) ([]extraComponentReference, error) {
+	for _, label := range descriptor.Component.Labels {
+		if label.Name == LabelExtraComponentReferences {
+			var refs []extraComponentReference
+			data, err := label.Value.MarshalJSON()
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal label value: %w", err)
+			}
+			err = json.Unmarshal(data, &refs)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal label value into []extraComponentReference: %w", err)
+			}
+			return refs, nil
+		}
+	}
+	return nil, nil
 }

--- a/pkg/ocm/components/components_test.go
+++ b/pkg/ocm/components/components_test.go
@@ -29,6 +29,7 @@ const (
 	refRoot                           = ComponentReference("example.com/kubernetes-root-example:0.1499.0")
 	refRuntimeGvisor                  = ComponentReference("github.com/gardener/gardener-extension-runtime-gvisor:v0.30.0")
 	gardenletHelmChartImageMapContent = `{"helmchartResource": {"name": "gardenlet"}, "imageMapping": [{"resource": {"name": "gardenlet"}, "repository": "image.repository", "tag": "image.tag"}]}`
+	expectedComponentCount            = 25
 )
 
 var _ = Describe("Components", func() {
@@ -119,7 +120,7 @@ var _ = Describe("Components", func() {
 
 	It("should produce correct image vector for gardener/gardener for rewritten images in OCM components", func() {
 		loadWithDep(3, refRoot)
-		Expect(c.ComponentsCount()).To(Equal(24))
+		Expect(c.ComponentsCount()).To(Equal(expectedComponentCount))
 		roots := c.GetRootComponents()
 		Expect(roots).To(ConsistOf(refRoot))
 		imageVector, err := c.GetImageVector(refGardener, false)
@@ -353,7 +354,7 @@ scheduler:
 
 	It("should produce correct image vector for gardener/gardener with original reference", func() {
 		loadWithDep(3, refRoot)
-		Expect(c.ComponentsCount()).To(Equal(24))
+		Expect(c.ComponentsCount()).To(Equal(expectedComponentCount))
 		roots := c.GetRootComponents()
 		Expect(roots).To(ConsistOf(refRoot))
 		imageVector, err := c.GetImageVector(refGardener, true)
@@ -463,7 +464,7 @@ scheduler:
 
 	It("should produce correct image vector for runtime-gvisor", func() {
 		loadWithDep(3, refRoot)
-		Expect(c.ComponentsCount()).To(Equal(24))
+		Expect(c.ComponentsCount()).To(Equal(expectedComponentCount))
 		roots := c.GetRootComponents()
 		Expect(roots).To(ConsistOf(refRoot))
 
@@ -478,6 +479,13 @@ scheduler:
 				Tag:        new("v0.30.0@sha256:86e26f6190ef103e9431a2897e38053e0ef2e06b30d20cdcc303827dac966a18"),
 				Version:    new("v0.30.0"),
 			}))
+	})
+
+	It("should contain extra component reference", func() {
+		loadWithDep(3, refRoot)
+		Expect(c.ComponentsCount()).To(Equal(expectedComponentCount))
+
+		Expect(c.GetSortedComponents()).To(ContainElements(ComponentReference("github.com/gardener/diki:v0.25.0")))
 	})
 })
 

--- a/pkg/ocm/components/const.go
+++ b/pkg/ocm/components/const.go
@@ -17,6 +17,9 @@ const (
 	// LabelNameOriginalRef is the label name for storing the original reference of a component
 	LabelNameOriginalRef = "cloud.gardener.cnudie/migration/original_ref"
 
+	// LabelExtraComponentReferences is a component label to add extra component references. Such references are used to add components without replication in RBSC.
+	LabelExtraComponentReferences = "ocm.software/ocm-gear/extra-component-references"
+
 	labelNameImageVectorRepository       = "imagevector.gardener.cloud/repository"
 	labelNameImageVectorSourceRepository = "imagevector.gardener.cloud/source-repository"
 	labelNameImageVectorTargetVersion    = "imagevector.gardener.cloud/target-version"

--- a/pkg/ocm/components/const.go
+++ b/pkg/ocm/components/const.go
@@ -17,7 +17,7 @@ const (
 	// LabelNameOriginalRef is the label name for storing the original reference of a component
 	LabelNameOriginalRef = "cloud.gardener.cnudie/migration/original_ref"
 
-	// LabelExtraComponentReferences is a component label to add extra component references. Such references are used to add components without replication in RBSC.
+	// LabelExtraComponentReferences is a component label to add extra component references. Such references are used to add components without replication.
 	LabelExtraComponentReferences = "ocm.software/ocm-gear/extra-component-references"
 
 	labelNameImageVectorRepository       = "imagevector.gardener.cloud/repository"

--- a/pkg/ocm/components/testdata/config.yaml
+++ b/pkg/ocm/components/testdata/config.yaml
@@ -41,4 +41,8 @@ components:
     version: v0.30.0
     componentName: "github.com/gardener/gardener-extension-runtime-gvisor"
 
+extraComponentReferences:
+  - componentName: "github.com/gardener/diki"
+    version: "v0.25.0"
+
 targetRepositoryURL: registry.example.com/path/to/repo

--- a/pkg/ocm/components/testdata/example.com_kubernetes-root-example-0.1499.0.json
+++ b/pkg/ocm/components/testdata/example.com_kubernetes-root-example-0.1499.0.json
@@ -9,6 +9,17 @@
       {
         "name": "imagevector.gardener.cloud/application",
         "value": "kubernetes"
+      },
+      {
+        "name": "ocm.software/ocm-gear/extra-component-references",
+        "value": [
+          {
+            "component_reference": {
+              "name": "github.com/gardener/diki",
+              "version": "v0.25.0"
+            }
+          }
+        ]
       }
     ],
     "provider": "test-resources",

--- a/pkg/ocm/components/testdata/github.com_gardener_diki-v0.25.0.json
+++ b/pkg/ocm/components/testdata/github.com_gardener_diki-v0.25.0.json
@@ -1,0 +1,289 @@
+{
+  "meta": {
+    "schemaVersion": "v2"
+  },
+  "component": {
+    "name": "github.com/gardener/diki",
+    "version": "v0.25.0",
+    "creationTime": "2026-03-12T15:09:59Z",
+    "repositoryContexts": [
+      {
+        "baseUrl": "europe-docker.pkg.dev/gardener-project/releases",
+        "subPath": null,
+        "type": "ociRegistry"
+      }
+    ],
+    "provider": "SAP SE",
+    "resources": [
+      {
+        "name": "diki",
+        "version": "v0.25.0",
+        "extraIdentity": {
+          "architecture": "arm64",
+          "os": "darwin"
+        },
+        "type": "executable",
+        "relation": "local",
+        "access": {
+          "globalAccess": null,
+          "localReference": "sha256:b10259bce9af82e644b4fd7cabc63bb1208d907a7ad80ab6f3d297e0986e3434",
+          "mediaType": "application/data",
+          "referenceName": null,
+          "size": 101512498,
+          "type": "localBlob/v1"
+        }
+      },
+      {
+        "name": "diki",
+        "version": "v0.25.0",
+        "extraIdentity": {
+          "architecture": "arm64",
+          "os": "linux"
+        },
+        "type": "executable",
+        "relation": "local",
+        "access": {
+          "globalAccess": null,
+          "localReference": "sha256:7f318135a1060f7aa2abae21759688651f09660fa47489e2b05b5a75b466edc0",
+          "mediaType": "application/data",
+          "referenceName": null,
+          "size": 97453644,
+          "type": "localBlob/v1"
+        }
+      },
+      {
+        "name": "diki",
+        "version": "v0.25.0",
+        "extraIdentity": {
+          "architecture": "amd64",
+          "os": "windows"
+        },
+        "type": "executable",
+        "relation": "local",
+        "access": {
+          "globalAccess": null,
+          "localReference": "sha256:f1cf20f38ad181afddff9e2ad5feb86eadd7302d66c55da3eed10787e296729e",
+          "mediaType": "application/data",
+          "referenceName": null,
+          "size": 104221184,
+          "type": "localBlob/v1"
+        }
+      },
+      {
+        "name": "diki",
+        "version": "v0.25.0",
+        "extraIdentity": {
+          "architecture": "amd64",
+          "os": "linux"
+        },
+        "type": "executable",
+        "relation": "local",
+        "access": {
+          "globalAccess": null,
+          "localReference": "sha256:596c4fbedfa380539d7106adde111598d4d4a6cca5bf575e35d529a93a442c69",
+          "mediaType": "application/data",
+          "referenceName": null,
+          "size": 103136163,
+          "type": "localBlob/v1"
+        }
+      },
+      {
+        "name": "diki",
+        "version": "v0.25.0",
+        "labels": [
+          {
+            "name": "gardener.cloud/cve-categorisation",
+            "value": {
+              "authentication_enforced": false,
+              "availability_requirement": "none",
+              "confidentiality_requirement": "high",
+              "integrity_requirement": "high",
+              "network_exposure": "protected",
+              "user_interaction": "end-user"
+            }
+          },
+          {
+            "name": "cloud.gardener.cnudie/migration/original_ref",
+            "value": "europe-docker.pkg.dev/gardener-project/releases/gardener/diki:v0.25.0"
+          }
+        ],
+        "extraIdentity": {
+          "version": "v0.25.0"
+        },
+        "type": "ociImage",
+        "relation": "local",
+        "access": {
+          "imageReference": "registry.example.com/path/to/repo/europe-docker_pkg_dev/gardener-project/releases/gardener/diki:v0.25.0@sha256:a14f7e53557a77de2fa178be2123214831175dccf8f9ba28ee0b847770d956e0",
+          "type": "ociRegistry"
+        }
+      },
+      {
+        "name": "gosec-report",
+        "version": "v0.25.0",
+        "labels": [
+          {
+            "name": "gardener.cloud/purposes",
+            "value": [
+              "lint",
+              "sast",
+              "gosec"
+            ]
+          },
+          {
+            "name": "gardener.cloud/comment",
+            "value": "we use gosec (linter) for SAST scans\nsee: https://github.com/securego/gosec\nEnabled by https://github.com/gardener/diki/pull/333\n"
+          }
+        ],
+        "type": "application/gzip",
+        "relation": "local",
+        "access": {
+          "globalAccess": null,
+          "localReference": "sha256:b48ecb7c1e3117ceac47d899aff66fc75aa1c1cbbd8f03148caa879b3db90dbb",
+          "mediaType": "application/data",
+          "referenceName": null,
+          "size": 1552,
+          "type": "localBlob/v1"
+        }
+      },
+      {
+        "name": "test-results",
+        "version": "v0.25.0",
+        "labels": [
+          {
+            "name": "gardener.cloud/purposes",
+            "value": [
+              "test"
+            ]
+          }
+        ],
+        "type": "application/gzip",
+        "relation": "local",
+        "access": {
+          "globalAccess": null,
+          "localReference": "sha256:7d04962f4a0996450cc29f7688fe6f2781691600d4e3739624a3a182d5377529",
+          "mediaType": "application/data",
+          "referenceName": null,
+          "size": 14725,
+          "type": "localBlob/v1"
+        }
+      },
+      {
+        "name": "diki",
+        "version": "v0.25.0",
+        "extraIdentity": {
+          "architecture": "amd64",
+          "os": "darwin"
+        },
+        "type": "executable",
+        "relation": "local",
+        "access": {
+          "globalAccess": null,
+          "localReference": "sha256:8a3bfbff119a0096014f78bbf48358de417097465df86fe080990a74d0110f1d",
+          "mediaType": "application/data",
+          "referenceName": null,
+          "size": 106437856,
+          "type": "localBlob/v1"
+        }
+      },
+      {
+        "name": "diki-ops",
+        "version": "v0.25.0",
+        "labels": [
+          {
+            "name": "imagevector.gardener.cloud/name",
+            "value": "diki-ops"
+          },
+          {
+            "name": "imagevector.gardener.cloud/repository",
+            "value": "europe-docker.pkg.dev/gardener-project/releases/gardener/diki-ops"
+          },
+          {
+            "name": "imagevector.gardener.cloud/source-repository",
+            "value": "github.com/gardener/diki"
+          },
+          {
+            "name": "cloud.gardener.cnudie/migration/original_ref",
+            "value": "europe-docker.pkg.dev/gardener-project/releases/gardener/diki-ops:v0.25.0"
+          }
+        ],
+        "type": "ociImage",
+        "relation": "local",
+        "access": {
+          "imageReference": "registry.example.com/path/to/repo/europe-docker_pkg_dev/gardener-project/releases/gardener/diki-ops:v0.25.0@sha256:d5bc0b2ce853eddfc9ac295d6de304f311fa2cf9c0f4f82925d6a9aeb4d376dd",
+          "type": "ociRegistry"
+        }
+      },
+      {
+        "name": "release-notes",
+        "version": "v0.25.0",
+        "type": "text/markdown.release-notes",
+        "relation": "local",
+        "access": {
+          "globalAccess": null,
+          "localReference": "sha256:6ec455373e32c2b8b494bd46c079ff61d3a4a775c70edf278defbfbf6eef6e25",
+          "mediaType": "text/markdown.release-notes",
+          "referenceName": null,
+          "size": 933,
+          "type": "localBlob/v1"
+        }
+      },
+      {
+        "name": "release-notes-archive",
+        "version": "v0.25.0",
+        "type": "application/tar.release-notes",
+        "relation": "local",
+        "access": {
+          "globalAccess": null,
+          "localReference": "sha256:a4c26a76f30001ac863566a285db26b3f9189a1ed2cf4dc44e3493656203d741",
+          "mediaType": "application/tar.release-notes",
+          "referenceName": null,
+          "size": 3072,
+          "type": "localBlob/v1"
+        }
+      },
+      {
+        "name": "branch-info",
+        "version": "v0.25.0",
+        "type": "application/vnd.gardener.cloud.branch-info+yaml",
+        "relation": "local",
+        "access": {
+          "globalAccess": null,
+          "localReference": "sha256:a02a6850eb5308ed14b09424b3dbe14aeb59687de9e88a62fa2d0ab5a57e43c7",
+          "mediaType": "application/vnd.gardener.cloud.branch-info+yaml",
+          "referenceName": null,
+          "size": 356,
+          "type": "localBlob/v1"
+        }
+      }
+    ],
+    "sources": [
+      {
+        "name": "main-source",
+        "version": "v0.25.0",
+        "labels": [
+          {
+            "name": "cloud.gardener/cicd/source",
+            "value": {
+              "repository-classification": "main"
+            }
+          },
+          {
+            "name": "cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1",
+            "value": {
+              "comment": "we use gosec for sast scanning. See attached log.\n",
+              "policy": "skip"
+            }
+          }
+        ],
+        "type": "git",
+        "access": {
+          "commit": "a6e705efe45bd5205a51a0c9fc4d03c753be05f0",
+          "ref": "refs/heads/main",
+          "repoUrl": "github.com/gardener/diki",
+          "type": "github"
+        }
+      }
+    ],
+    "componentReferences": []
+  }
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
  This PR adds support for extra component references in OCM component descriptors, allowing components to be added without requiring replication in RBSC (Repository-Based Supply Chain).                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                    
  Changes                                                                                                                                                                                                                                                                                                                                           
                                                                                              
  Core functionality:                                                                                                                                                                                                                                                                                                                               
  - Added LabelExtraComponentReferences constant (ocm.software/ocm-gear/extra-component-references) to identify the component label
  - Implemented extraReferences() function to extract extra component references from descriptor labels                                                                                                                                                                                                                                             
  - Updated AddComponentDependencies() to process extra references and add them as dependencies        
                                                                                                                                                                                                                                                                                                                                                    
  Test data generation:                                                                                                                                                                                                                                                                                                                             
  - Extended OCM testdata generator to support extra component references configuration                                                                                                                                                                                                                                                             
  - Added ExtraComponentRef type to configuration schema                                                                                                                                                                                                                                                                                            
  - Updated generator to create test components with extra references label                                                                                                                                                                                                                                                                         
  - Fixed label value handling to use json.RawMessage for proper type safety                                                                                                                                                                                                                                                                        
  - Added github.com/gardener/diki:v0.25.0 as test component with extra reference                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                    
  Testing:                                                                                                                                                                                                                                                                                                                                          
  - Added test case to verify extra component references are properly loaded                                                                                                                                                                                                                                                                        
  - Updated existing test assertions to account for additional component (25 total instead of 24) 
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support extra component references in OCM component descriptors
```
