### PR TITLE
Override status check on the pushed generate commit

### DIFF
--- a/.github/workflows/glk.yaml
+++ b/.github/workflows/glk.yaml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: 'chore: run gardener-landscape-kit'
+      status-context:
+        description: 'GitHub commit status context name to set on the pushed commit (must match the required check name in branch protection)'
+        required: false
+        type: string
+        default: 'glk-generate / glk'
 
 jobs:
   glk:
@@ -30,6 +35,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      statuses: write
 
     steps:
     - name: Checkout PR branch
@@ -51,6 +57,7 @@ jobs:
         commands: ${{ inputs.glk-commands }}
 
     - name: Commit and push changes
+      id: push
       run: |
         git add .
         if git diff --cached --quiet; then
@@ -58,4 +65,15 @@ jobs:
         else
           git commit -m "${{ inputs.commit-message }}"
           git push origin HEAD:${{ github.event.pull_request.head.ref || github.ref_name }}
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         fi
+
+    - name: Set status on pushed commit
+      if: steps.push.outputs.pushed == 'true'
+      run: |
+        curl -sfS -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github+json" \
+          "${{ github.api_url }}/repos/${{ github.repository }}/statuses/${{ steps.push.outputs.sha }}" \
+          -d "{\"state\":\"success\",\"context\":\"${{ inputs.status-context }}\",\"description\":\"GLK generation completed\"}"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Commits added from an action do not trigger the action again (to avoid infinite loops). Hence, the check status needs to be overridden for required checks to be deemed as passed.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
