### PR TITLE
Add `install.sh` to retrieve a `glk` binary for the version in the `components.yaml`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,12 +92,27 @@ jobs:
           - os: linux
             arch: amd64
             runner: ubuntu-latest
+            archive_suffix: .tar.gz
+          - os: linux
+            arch: arm64
+            runner: ubuntu-latest
+            archive_suffix: .tar.gz
           - os: darwin
             arch: amd64
             runner: ubuntu-latest
+            archive_suffix: .tar.gz
+          - os: darwin
+            arch: arm64
+            runner: ubuntu-latest
+            archive_suffix: .tar.gz
           - os: windows
             arch: amd64
             runner: ubuntu-latest
+            archive_suffix: .zip
+          - os: windows
+            arch: arm64
+            runner: ubuntu-latest
+            archive_suffix: .zip
     runs-on: ${{ matrix.args.runner }}
     steps:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
@@ -114,17 +129,15 @@ jobs:
 
           if [ ${os} == 'windows' ]; then
             exe_suffix='.exe'
-            archive_suffix='.zip'
           else
             exe_suffix=''
-            archive_suffix='.tar.gz'
           fi
 
           mkdir -p /tmp/blobs.d
           prefix=/tmp/blobs.d/gardener-landscape-kit
           platform_suffix="-${os}-${arch}"
-          outpath="${prefix}${platform_suffix}${exe_suffix}${archive_suffix}"
-          archive="${prefix}${platform_suffix}.archive"
+          outpath="${prefix}${platform_suffix}${exe_suffix}"
+          archive="${prefix}${platform_suffix}${{ matrix.args.archive_suffix }}.archive"
 
           GOOS=${os} \
           GOARCH=${arch} \
@@ -141,7 +154,7 @@ jobs:
               zip -j ${archive} $(basename ${outpath})
             )
           else
-            tar cvzf ${archive} -C/tmp/blobs.d $(basename ${outpath})
+            tar cvzf ${archive} -C /tmp/blobs.d $(basename ${outpath})
           fi
 
           unlink ${outpath}
@@ -158,7 +171,7 @@ jobs:
             access:
               type: localBlob
               localReference: >-
-                gardener-landscape-kit-${{ matrix.args.os }}-${{ matrix.args.arch }}.archive
+                gardener-landscape-kit-${{ matrix.args.os }}-${{ matrix.args.arch }}${{ matrix.args.archive_suffix }}.archive
 
   oci-images:
     name: Build OCI-Images

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,37 +35,37 @@ jobs:
       next-version: ${{ inputs.next-version }}
       next-version-callback-action-path: .github/actions/prepare-release
       assets: |
-        - name: gardener-landscape-kit-darwin-amd64
+        - name: gardener-landscape-kit-darwin-amd64.tar.gz
           type: ocm-resource
           id:
             name: gardener-landscape-kit
             os: darwin
             architecture: amd64
-        - name: gardener-landscape-kit-darwin-arm64
+        - name: gardener-landscape-kit-darwin-arm64.tar.gz
           type: ocm-resource
           id:
             name: gardener-landscape-kit
             os: darwin
             architecture: arm64
-        - name: gardener-landscape-kit-linux-amd64
+        - name: gardener-landscape-kit-linux-amd64.tar.gz
           type: ocm-resource
           id:
             name: gardener-landscape-kit
             os: linux
             architecture: amd64
-        - name: gardener-landscape-kit-linux-arm64
+        - name: gardener-landscape-kit-linux-arm64.tar.gz
           type: ocm-resource
           id:
             name: gardener-landscape-kit
             os: linux
             architecture: arm64
-        - name: gardener-landscape-kit-windows-amd64
+        - name: gardener-landscape-kit-windows-amd64.zip
           type: ocm-resource
           id:
             name: gardener-landscape-kit
             os: windows
             architecture: amd64
-        - name: gardener-landscape-kit-windows-arm64
+        - name: gardener-landscape-kit-windows-arm64.zip
           type: ocm-resource
           id:
             name: gardener-landscape-kit

--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@
 > [!WARNING]
 > This project is under active development. Breaking changes may occur frequently. Not ready for production use.
 
+## Getting Started
+
+1. Obtain the `components.yaml` for the desired GLK release.
+2. Run the install script, pointing it at that file:
+
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/gardener/gardener-landscape-kit/HEAD/install.sh)" -- \
+     --components-file path/to/components.yaml
+   ```
+
+   This downloads the matching `glk` binary to `~/.glk/bin/` and prints next steps.
+
 `gardener-landscape-kit`, short GLK, is a toolkit for generating manifests to facilitate GitOps-based management of Gardener landscapes.
 
 ## Scope

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# install.sh — downloads the gardener-landscape-kit binary matching the version
+# specified in a components.yaml file.
+#
+# Usage:
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/gardener/gardener-landscape-kit/HEAD/install.sh)"
+#   /bin/bash -c "$(curl -fsSL ...)" -- --components-file path/to/components.yaml --install-dir ~/.local/bin
+#
+# Options:
+#   --components-file PATH   Path to components.yaml (default: ./components.yaml)
+#   --install-dir DIR        Directory to install the binary into (default: ~/.glk/bin)
+#   --no-symlink             Do not create/update a 'glk' symlink in install-dir
+#   --help                   Print this help
+#
+# END_HELP
+
+GITHUB_REPO="gardener/gardener-landscape-kit"
+GLK_COMPONENT_NAME="github.com/gardener/gardener-landscape-kit"
+BINARY_NAME="gardener-landscape-kit"
+
+# Defaults
+COMPONENTS_FILE="${COMPONENTS_FILE:-./components.yaml}"
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.glk/bin}"
+CREATE_SYMLINK=true
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+log() { echo "[glk-install] $*"; }
+die() { echo "[glk-install] ERROR: $*" >&2; exit 1; }
+
+usage() {
+  awk '/^# install\.sh/,/^# END_HELP/' "$0" | grep -v '^# END_HELP' | sed 's/^# \{0,2\}//'
+  exit 0
+}
+
+# ── argument parsing ──────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --components-file) COMPONENTS_FILE="$2"; shift 2 ;;
+    --install-dir)     INSTALL_DIR="$2";     shift 2 ;;
+    --no-symlink)      CREATE_SYMLINK=false; shift   ;;
+    --help|-h)         usage ;;
+    *) die "Unknown argument: $1. Run with --help for usage." ;;
+  esac
+done
+
+# ── detect version from components.yaml ──────────────────────────────────────
+
+[[ -f "$COMPONENTS_FILE" ]] || die "components.yaml not found at '$COMPONENTS_FILE'. Pass --components-file PATH."
+
+# Extract the version field of the GLK entry.
+# The YAML structure is:
+#   components:
+#   - name: github.com/gardener/gardener-landscape-kit
+#     version: vX.Y.Z
+#
+# We look for the name line, then grab the next 'version:' line that follows.
+VERSION="$(awk -v component="${GLK_COMPONENT_NAME}" '
+  index($0, "name:") && index($0, component) { found=1; next }
+  found && index($0, "version:") { print; exit }
+' "$COMPONENTS_FILE" | sed 's/.*version:[[:space:]]*["'\'']\{0,1\}\([^"'\'' ]*\)["'\'']\{0,1\}.*/\1/')"
+
+[[ -n "$VERSION" ]] || die "Could not find version for '${GLK_COMPONENT_NAME}' in '$COMPONENTS_FILE'."
+
+log "Found GLK version: ${VERSION}"
+
+# ── detect OS and architecture ────────────────────────────────────────────────
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$OS" in
+  linux)   OS="linux" ;;
+  darwin)  OS="darwin" ;;
+  mingw*|msys*|cygwin*|windows*) OS="windows" ;;
+  *) die "Unsupported OS: $(uname -s)" ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64)    ARCH="amd64" ;;
+  aarch64|arm64)   ARCH="arm64" ;;
+  *) die "Unsupported architecture: $(uname -m)" ;;
+esac
+
+ASSET_NAME="${BINARY_NAME}-${OS}-${ARCH}"
+log "Platform: ${OS}/${ARCH} → asset '${ASSET_NAME}'"
+
+# ── resolve download URL ──────────────────────────────────────────────────────
+
+DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${ASSET_NAME}"
+
+# ── prepare install directory and target path ─────────────────────────────────
+
+mkdir -p "$INSTALL_DIR"
+VERSIONED_BINARY="${INSTALL_DIR}/${ASSET_NAME}-${VERSION}"
+SYMLINK_PATH="${INSTALL_DIR}/glk"
+
+# Skip download if the exact versioned binary already exists
+if [[ -f "$VERSIONED_BINARY" ]]; then
+  log "Binary already cached at '${VERSIONED_BINARY}', skipping download."
+else
+  log "Downloading ${DOWNLOAD_URL} ..."
+  if command -v curl &>/dev/null; then
+    curl -fSL --progress-bar -o "$VERSIONED_BINARY" "$DOWNLOAD_URL" \
+      || die "Download failed. Verify that version '${VERSION}' exists at https://github.com/${GITHUB_REPO}/releases"
+  elif command -v wget &>/dev/null; then
+    wget -q --show-progress -O "$VERSIONED_BINARY" "$DOWNLOAD_URL" \
+      || die "Download failed. Verify that version '${VERSION}' exists at https://github.com/${GITHUB_REPO}/releases"
+  else
+    die "Neither curl nor wget found. Install one and retry."
+  fi
+  log "Downloaded to '${VERSIONED_BINARY}'."
+fi
+
+chmod +x "$VERSIONED_BINARY"
+
+# ── create / update symlink ───────────────────────────────────────────────────
+
+if [[ "$CREATE_SYMLINK" == true ]]; then
+  ln -sf "$VERSIONED_BINARY" "$SYMLINK_PATH"
+  log "Symlink updated: '${SYMLINK_PATH}' → '${VERSIONED_BINARY}'"
+fi
+
+# ── print next steps ──────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────────────"
+echo " gardener-landscape-kit ${VERSION} installed successfully"
+echo "────────────────────────────────────────────────────────"
+echo ""
+echo "Binary:  ${VERSIONED_BINARY}"
+if [[ "$CREATE_SYMLINK" == true ]]; then
+  echo "Symlink: ${SYMLINK_PATH}"
+fi
+echo ""
+
+# Check whether INSTALL_DIR is already in PATH
+if [[ ":${PATH}:" != *":${INSTALL_DIR}:"* ]]; then
+  echo "Add the install directory to your PATH by running:"
+  echo ""
+  echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
+  echo ""
+  echo "To make it permanent, add the line above to your ~/.bashrc or ~/.zshrc."
+  echo ""
+fi
+
+echo "Next steps:"
+echo ""
+echo "    glk generate base <TARGET_DIR>"
+echo ""

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,13 @@ download() {
 
 # ── resolve download URL ──────────────────────────────────────────────────────
 
-DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${ASSET_NAME}"
+if [[ "$OS" == "windows" ]]; then
+  ARCHIVE_SUFFIX=".zip"
+else
+  ARCHIVE_SUFFIX=".tar.gz"
+fi
+
+DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${ASSET_NAME}${ARCHIVE_SUFFIX}"
 
 # ── prepare install directory and target path ─────────────────────────────────
 
@@ -117,26 +123,58 @@ mkdir -p "$INSTALL_DIR"
 VERSIONED_BINARY="${INSTALL_DIR}/${ASSET_NAME}-${VERSION}"
 SYMLINK_PATH="${INSTALL_DIR}/glk"
 
+# ── extract helper ────────────────────────────────────────────────────────────
+
+extract_asset() {
+  local archive="$1" dest_dir="$2" binary_name="$3"
+  local dest="${dest_dir}/${binary_name}"
+
+  if [[ "$OS" == "windows" ]]; then
+    unzip -o -d "$dest_dir" "$archive"
+  else
+    tar xzf "$archive" -C "$dest_dir"
+  fi
+
+  if [[ -f "$dest" ]]; then
+    mv "$dest" "${VERSIONED_BINARY}"
+  else
+    die "Expected binary '${binary_name}' not found in archive."
+  fi
+}
+
+# ── download and install ──────────────────────────────────────────────────────
+
 # Skip download if the exact versioned binary already exists
 if [[ -f "$VERSIONED_BINARY" ]]; then
   log "Binary already cached at '${VERSIONED_BINARY}', skipping download."
 else
+  ARCHIVE_TMP="$(mktemp)"
+  trap 'rm -f "$ARCHIVE_TMP"' EXIT
+
   log "Downloading ${DOWNLOAD_URL} ..."
-  if ! download "$DOWNLOAD_URL" "$VERSIONED_BINARY"; then
-    rm -f "$VERSIONED_BINARY"
+  if ! download "$DOWNLOAD_URL" "$ARCHIVE_TMP"; then
     # On darwin/arm64, older releases may only ship amd64 — fall back via Rosetta
     if [[ "$OS" == "darwin" && "$ARCH" == "arm64" ]]; then
       log "arm64 asset not found, falling back to amd64 (runs via Rosetta 2)."
-      ASSET_NAME="${BINARY_NAME}-${OS}-amd64"
-      DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${ASSET_NAME}"
+      ARCH="amd64"
+      ASSET_NAME="${BINARY_NAME}-${OS}-${ARCH}"
+      DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${ASSET_NAME}${ARCHIVE_SUFFIX}"
       VERSIONED_BINARY="${INSTALL_DIR}/${ASSET_NAME}-${VERSION}"
-      download "$DOWNLOAD_URL" "$VERSIONED_BINARY" \
+      download "$DOWNLOAD_URL" "$ARCHIVE_TMP" \
         || die "Download failed. Check that version '${VERSION}' exists at https://github.com/${GITHUB_REPO}/releases"
     else
       die "Download failed. Check that version '${VERSION}' exists at https://github.com/${GITHUB_REPO}/releases"
     fi
   fi
-  log "Downloaded to '${VERSIONED_BINARY}'."
+
+  if [[ "$OS" == "windows" ]]; then
+    INNER_BINARY="${BINARY_NAME}-${OS}-${ARCH}.exe"
+  else
+    INNER_BINARY="${BINARY_NAME}-${OS}-${ARCH}"
+  fi
+
+  extract_asset "$ARCHIVE_TMP" "$INSTALL_DIR" "$INNER_BINARY"
+  log "Installed to '${VERSIONED_BINARY}'."
 fi
 
 chmod +x "$VERSIONED_BINARY"

--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,19 @@ esac
 ASSET_NAME="${BINARY_NAME}-${OS}-${ARCH}"
 log "Platform: ${OS}/${ARCH} → asset '${ASSET_NAME}'"
 
+# ── download helper ───────────────────────────────────────────────────────────
+
+download() {
+  local url="$1" dest="$2"
+  if command -v curl &>/dev/null; then
+    curl -fSL --progress-bar -o "$dest" "$url"
+  elif command -v wget &>/dev/null; then
+    wget -q --show-progress -O "$dest" "$url"
+  else
+    die "Neither curl nor wget found. Install one and retry."
+  fi
+}
+
 # ── resolve download URL ──────────────────────────────────────────────────────
 
 DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${ASSET_NAME}"
@@ -109,14 +122,19 @@ if [[ -f "$VERSIONED_BINARY" ]]; then
   log "Binary already cached at '${VERSIONED_BINARY}', skipping download."
 else
   log "Downloading ${DOWNLOAD_URL} ..."
-  if command -v curl &>/dev/null; then
-    curl -fSL --progress-bar -o "$VERSIONED_BINARY" "$DOWNLOAD_URL" \
-      || die "Download failed. Verify that version '${VERSION}' exists at https://github.com/${GITHUB_REPO}/releases"
-  elif command -v wget &>/dev/null; then
-    wget -q --show-progress -O "$VERSIONED_BINARY" "$DOWNLOAD_URL" \
-      || die "Download failed. Verify that version '${VERSION}' exists at https://github.com/${GITHUB_REPO}/releases"
-  else
-    die "Neither curl nor wget found. Install one and retry."
+  if ! download "$DOWNLOAD_URL" "$VERSIONED_BINARY"; then
+    rm -f "$VERSIONED_BINARY"
+    # On darwin/arm64, older releases may only ship amd64 — fall back via Rosetta
+    if [[ "$OS" == "darwin" && "$ARCH" == "arm64" ]]; then
+      log "arm64 asset not found, falling back to amd64 (runs via Rosetta 2)."
+      ASSET_NAME="${BINARY_NAME}-${OS}-amd64"
+      DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${ASSET_NAME}"
+      VERSIONED_BINARY="${INSTALL_DIR}/${ASSET_NAME}-${VERSION}"
+      download "$DOWNLOAD_URL" "$VERSIONED_BINARY" \
+        || die "Download failed. Check that version '${VERSION}' exists at https://github.com/${GITHUB_REPO}/releases"
+    else
+      die "Download failed. Check that version '${VERSION}' exists at https://github.com/${GITHUB_REPO}/releases"
+    fi
   fi
   log "Downloaded to '${VERSIONED_BINARY}'."
 fi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Add script to retrieve a matching glk binary for the `components.yaml` used.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy

Currently, this only works with the present release `v0.1.0`:

<details>
  <summary>Output of local test for `v0.1.0`</summary>
  
  Changed glk version in `./componentvector/components.yaml` to `v0.1.0`, then ran:
  
  ```javascript
   ./install.sh --components-file ./componentvector/components.yaml
[glk-install] Found GLK version: v0.1.0
[glk-install] Platform: darwin/arm64 → asset 'gardener-landscape-kit-darwin-arm64'
[glk-install] Downloading https://github.com/gardener/gardener-landscape-kit/releases/download/v0.1.0/gardener-landscape-kit-darwin-arm64 ...
curl: (56) The requested URL returned error: 404

[glk-install] arm64 asset not found, falling back to amd64 (runs via Rosetta 2).
######################################################################################################################################################################################################################################################### 100.0%
[glk-install] Downloaded to '/Users/I543201/.glk/bin/gardener-landscape-kit-darwin-amd64-v0.1.0'.
[glk-install] Symlink updated: '/Users/I543201/.glk/bin/glk' → '/Users/I543201/.glk/bin/gardener-landscape-kit-darwin-amd64-v0.1.0'

────────────────────────────────────────────────────────
 gardener-landscape-kit v0.1.0 installed successfully
────────────────────────────────────────────────────────

Binary:  /Users/I543201/.glk/bin/gardener-landscape-kit-darwin-amd64-v0.1.0
Symlink: /Users/I543201/.glk/bin/glk

Add the install directory to your PATH by running:

    export PATH="/Users/I543201/.glk/bin:$PATH"

To make it permanent, add the line above to your ~/.bashrc or ~/.zshrc.

Next steps:

    glk generate base <TARGET_DIR>


  ```
  
</details> 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added `install.sh` script to get started easier. Retrieving a glk binary for the correct version as specified in the used `components.yaml` is now as simple as: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/gardener/gardener-landscape-kit/HEAD/install.sh)" -- --components-file path/to/components.yaml`.
```
