### PR TITLE
Allow including `Flux` component only

### DIFF
--- a/pkg/utils/kustomization/kustomization.go
+++ b/pkg/utils/kustomization/kustomization.go
@@ -5,6 +5,7 @@
 package kustomization
 
 import (
+	"fmt"
 	"maps"
 	"os"
 	"path"
@@ -68,6 +69,14 @@ func WriteLandscapeComponentsKustomizations(options components.Options) error {
 	fs := options.GetFilesystem()
 	targetDir := options.GetTargetPath()
 	componentsDir := filepath.Join(targetDir, components.DirName)
+
+	componentsExist, err := fs.Exists(componentsDir)
+	if err != nil {
+		return fmt.Errorf("failed checking components dir: %w", err)
+	}
+	if !componentsExist {
+		return nil
+	}
 
 	return fs.Walk(componentsDir, writeKustomizationsToFileTree(fs, targetDir, options.GetMergeMode()))
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Allows including `Flux` component only. Earlier the generation failed with:

```
components: no such file or directory
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented to include the `Flux` component only.
```
