### PR TITLE
Implement `github` component to write action and workflow to target repositories

### DIFF
--- a/.github/github.go
+++ b/.github/github.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package github exposes the subset of this repository's .github/ assets that are intended for re-use in consumer landscape repositories.
+// The github GLK component (pkg/components/github) materializes these into a target repo.
+package github
+
+import "embed"
+
+// DotGitHubActions embeds the composite actions consumed by the reusable workflows shipped with GLK.
+// Only the action(s) usable by GLK consumers are included; CI-only actions (e.g. prepare-release) are intentionally excluded.
+//
+//go:embed actions/glk
+var DotGitHubActions embed.FS
+
+// DotGitHubWorkflows embeds the reusable workflows shipped with GLK for use in consumer landscape repositories.
+// CI-only workflows that build/release GLK itself are intentionally excluded.
+//
+//go:embed workflows/glk.yaml
+var DotGitHubWorkflows embed.FS

--- a/docs/concepts/integration.md
+++ b/docs/concepts/integration.md
@@ -62,7 +62,7 @@ Once the initial setup is complete, operators should integrate GLK into their re
 GLK is designed to be integrated into workflow engines that are tightly coupled with the Git repositories hosting `base` and `landscape` configurations. This allows the workflow to react automatically to changes introduced via pull requests or other means.
 
 > [!IMPORTANT]
-> Workflow automation engines (such as [GitHub Actions](https://github.com/features/actions) or [GitLab CI/CD](https://docs.gitlab.com/ci/)) should not be confused with [Flux](https://fluxcd.io/), which is the backing deployment engine for Gardener, extensions, and related configurations. Flux is responsible for continuously deploying manifests from Git to the Kubernetes cluster. In a production-grade setup, however, usually more automation is required around the landscape deployment. Many operational processes — such as testing, release workflows, validation jobs, and similar tasks — are better integrated with the version control system itself (i.e., the CI/CD platform) rather than running within Flux.
+> Workflow automation engines (such as [GitHub Actions](https://github.com/features/actions) or [GitLab CI/CD](https://docs.gitlab.com/ci/)) should not be confused with [Flux](https://fluxcd.io/), which is the backing deployment engine for Gardener, extensions, and related configurations. Flux is responsible for continuously deploying manifests from Git to the Kubernetes cluster. In a production-grade setup, however, usually more automation is required around the landscape deployment. Many operational processes, such as testing, release workflows, validation jobs, and similar tasks, are better integrated with the version control system itself (i.e., the CI/CD platform) rather than running within Flux.
 
 **Recommended workflow engines:**
 - [GitHub Actions](https://github.com/features/actions)
@@ -123,16 +123,22 @@ GLK operations should be triggered based on specific events in the repository li
 
 ### GitHub Actions Integration
 
-GLK provides reusable GitHub Actions and workflows to facilitate automation:
+GLK ships a reusable GitHub Action and a reusable workflow that automate `glk` invocations.
+They can be consumed in two ways:
 
-#### Reusable Workflow: `.github/workflows/glk.yaml`
+1. **Reference them directly from `github.com/gardener/gardener-landscape-kit`.** This is the simplest option for repositories hosted on github.com.
+2. **Have GLK materialize them into your own repository's `.github/` directory** via the [`github` component](#github-component). This is intended for GitHub Enterprise (GHE) or other custom VCS instances where referencing external repositories is not possible.
 
-This workflow can be called from other workflows to execute GLK commands in a pull request context. It:
+Both options expose the same action and workflow.
+
+#### Reusable Workflow: `workflows/glk.yaml`
+
+This workflow can be called from another workflow to execute GLK commands in a pull request context. It:
 - Checks out the PR branch
-- Runs specified GLK commands
+- Runs the specified GLK commands
 - Commits any changes back to the PR branch
 
-**Example usage in a repository workflow**:
+**Example: referencing the published workflow on github.com**:
 
 ```yaml
 name: GLK Generate on PR
@@ -150,17 +156,27 @@ jobs:
       commit-message: 'chore: run gardener-landscape-kit'
 ```
 
-#### GitHub Action: `.github/actions/glk/action.yaml`
+**Example: referencing a copy materialized into your own repo by the `github` component**:
 
-This composite action runs GLK commands using the container image version specified in `components.yaml`. It can be used directly in workflow steps.
+```yaml
+jobs:
+  generate:
+    uses: ./.github/workflows/glk.yaml
+    with:
+      ...
+```
 
-**Example usage**:
+#### Composite Action: `actions/glk/action.yaml`
+
+This composite action runs GLK commands using the container image version specified in `components.yaml`. Use it directly from a step.
+
+**Example: referencing the published action on github.com**:
 
 ```yaml
 steps:
   - name: Checkout
     uses: actions/checkout@v6
-  
+
   - name: Run GLK
     uses: gardener/gardener-landscape-kit/.github/actions/glk@main
     with:
@@ -168,6 +184,30 @@ steps:
       commands: |
         resolve ocm -c landscape/glk.yaml .
         generate landscape -c landscape/glk.yaml .
+```
+
+**Example: referencing a copy materialized into your own repo by the `github` component**:
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: ./.github/actions/glk
+    with:
+      ...
+```
+
+#### `github` component
+
+The `github` GLK component materializes reusable actions and workflows into the consumer repository's `.github/` directory at the repository root. It is the alternative consumption model for the action and workflow above, primarily intended for GitHub Enterprise instances or other restricted environments where direct cross-repository references to `github.com/gardener/...` are not possible.
+
+It runs as part of both `glk generate base` and `glk generate landscape`, and follows the same path convention as all other GLK components: `glk` is invoked from the repository root, with `paths.base` and `paths.landscape` in the configuration being repo-relative paths.
+
+The `github` component is **included by default**. If you reference the published versions on github.com (or manage your own copies of these files), add `github` to `components.exclude` in your `glk.yaml` to prevent GLK from overwriting them:
+
+```yaml
+components:
+  exclude:
+  - github
 ```
 
 ### Automation Patterns

--- a/example/20-componentconfig-glk.yaml
+++ b/example/20-componentconfig-glk.yaml
@@ -20,9 +20,6 @@ kind: LandscapeKitConfiguration
 # components:
 #   exclude:
 #   - component-name
-#   # The github component is included by default. To disable it (e.g. if you
-#   # manage your own .github/actions/glk and .github/workflows/glk.yaml), add:
-#   # - github
 # versionConfig:
 #   defaultVersionsUpdateStrategy: ReleaseBranch
 #   checkMode: Strict # or Warning

--- a/example/20-componentconfig-glk.yaml
+++ b/example/20-componentconfig-glk.yaml
@@ -20,6 +20,9 @@ kind: LandscapeKitConfiguration
 # components:
 #   exclude:
 #   - component-name
+#   # The github component is included by default. To disable it (e.g. if you
+#   # manage your own .github/actions/glk and .github/workflows/glk.yaml), add:
+#   # - github
 # versionConfig:
 #   defaultVersionsUpdateStrategy: ReleaseBranch
 #   checkMode: Strict # or Warning

--- a/pkg/components/github/component.go
+++ b/pkg/components/github/component.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+
+	dotgithub "github.com/gardener/gardener-landscape-kit/.github"
+	"github.com/gardener/gardener-landscape-kit/pkg/components"
+	"github.com/gardener/gardener-landscape-kit/pkg/utils/files"
+)
+
+// ComponentName is the name of the github component.
+const ComponentName = "github"
+
+// dotGitHubDir is the destination directory at the repository root.
+const dotGitHubDir = ".github"
+
+// DisclaimerHeader is prepended to every file written by this component.
+const DisclaimerHeader = `# This file is managed by gardener-landscape-kit (github component) and will be
+# overwritten on every 'glk generate' invocation. To stop glk from managing
+# this file, exclude the 'github' component in your glk configuration:
+#
+#   components:
+#     exclude:
+#     - github
+#
+`
+
+type component struct{}
+
+// NewComponent creates a new github component.
+func NewComponent() components.Interface {
+	return &component{}
+}
+
+// Name returns the component name.
+func (*component) Name() string {
+	return ComponentName
+}
+
+// GenerateBase materializes the embedded .github/ assets into the repository root during base generation.
+func (*component) GenerateBase(opts components.Options) error {
+	return writeDotGitHub(opts)
+}
+
+// GenerateLandscape materializes the embedded .github/ assets into the repository root during landscape generation.
+func (*component) GenerateLandscape(opts components.LandscapeOptions) error {
+	return writeDotGitHub(opts)
+}
+
+// writeDotGitHub walks the embedded sources and writes each file directly to the repository root with the disclaimer header prepended, overwriting any existing content.
+func writeDotGitHub(opts components.Options) error {
+	dotGitHubRoot := path.Join(opts.GetRepoRoot(), dotGitHubDir)
+	for _, src := range []struct {
+		fs   fs.FS
+		root string
+	}{
+		{dotgithub.DotGitHubActions, "actions"},
+		{dotgithub.DotGitHubWorkflows, "workflows"},
+	} {
+		if err := writeEmbedded(src.fs, src.root, dotGitHubRoot, opts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeEmbedded walks srcRoot in srcFS and writes each regular file's contents (with the disclaimer header prepended) to destRoot joined with the file's path relative to the embed root.
+// Files are always overwritten. No template rendering is performed (action/workflow YAML uses ${{ ... }} which would collide with Go template delimiters).
+func writeEmbedded(srcFS fs.FS, srcRoot, destRoot string, opts components.Options) error {
+	return fs.WalkDir(srcFS, srcRoot, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		contents, err := fs.ReadFile(srcFS, p)
+		if err != nil {
+			return fmt.Errorf("read embedded %s: %w", p, err)
+		}
+		withHeader := append([]byte(DisclaimerHeader), contents...)
+		destPath := path.Join(destRoot, p)
+		return files.WriteFileToFilesystem(withHeader, destPath, true, opts.GetFilesystem())
+	})
+}

--- a/pkg/components/github/component_test.go
+++ b/pkg/components/github/component_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/gardener/gardener-landscape-kit/pkg/components/github"
 )
 
-var _ = Describe("GitHubComponent", func() {
+var _ = Describe("Component Generation", func() {
 	var (
 		memFs        afero.Afero
 		generateOpts *generateoptions.Options

--- a/pkg/components/github/component_test.go
+++ b/pkg/components/github/component_test.go
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package github_test
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	dotgithub "github.com/gardener/gardener-landscape-kit/.github"
+	"github.com/gardener/gardener-landscape-kit/pkg/apis/config/v1alpha1"
+	"github.com/gardener/gardener-landscape-kit/pkg/cmd"
+	generateoptions "github.com/gardener/gardener-landscape-kit/pkg/cmd/generate/options"
+	"github.com/gardener/gardener-landscape-kit/pkg/components"
+	. "github.com/gardener/gardener-landscape-kit/pkg/components/github"
+)
+
+var _ = Describe("GitHubComponent", func() {
+	var (
+		memFs        afero.Afero
+		generateOpts *generateoptions.Options
+	)
+
+	BeforeEach(func() {
+		memFs = afero.Afero{Fs: afero.NewMemMapFs()}
+		generateOpts = &generateoptions.Options{
+			Options: &cmd.Options{Log: logr.Discard()},
+			Config:  &v1alpha1.LandscapeKitConfiguration{},
+		}
+		v1alpha1.SetObjectDefaults_LandscapeKitConfiguration(generateOpts.Config)
+	})
+
+	Describe("#Name", func() {
+		It("returns 'github'", func() {
+			Expect(NewComponent().Name()).To(Equal("github"))
+		})
+	})
+
+	Describe("#GenerateBase", func() {
+		Context("with repositories.base.target = 'base'", func() {
+			var opts components.Options
+
+			BeforeEach(func() {
+				generateOpts.TargetDirPath = "/repo"
+				generateOpts.Config.Repositories = &v1alpha1.RepositoriesConfig{
+					Base: &v1alpha1.BaseRepositoryConfig{Target: "base"},
+				}
+				v1alpha1.SetObjectDefaults_LandscapeKitConfiguration(generateOpts.Config)
+
+				var err error
+				opts, err = components.NewOptions(generateOpts, memFs)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("writes both .github files at the repository root", func() {
+				Expect(NewComponent().GenerateBase(opts)).To(Succeed())
+
+				for _, p := range []string{
+					"/repo/.github/actions/glk/action.yaml",
+					"/repo/.github/workflows/glk.yaml",
+				} {
+					exists, err := memFs.Exists(p)
+					Expect(err).NotTo(HaveOccurred(), "checking existence of %s", p)
+					Expect(exists).To(BeTrue(), "expected %s to exist", p)
+				}
+			})
+
+			It("writes only the expected subdirectories under .github/", func() {
+				Expect(NewComponent().GenerateBase(opts)).To(Succeed())
+
+				dirEntries, err := afero.ReadDir(memFs, "/repo/.github")
+				Expect(err).NotTo(HaveOccurred())
+
+				names := make([]string, 0, len(dirEntries))
+				for _, e := range dirEntries {
+					names = append(names, e.Name())
+				}
+				Expect(names).To(ConsistOf("actions", "workflows"))
+			})
+
+			It("does not create a .glk shadow tree under the target directory", func() {
+				Expect(NewComponent().GenerateBase(opts)).To(Succeed())
+
+				exists, err := memFs.DirExists("/repo/base/.glk")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exists).To(BeFalse(), "github component must not write a .glk/defaults shadow tree")
+			})
+
+			It("prepends the disclaimer header and preserves the embedded bytes verbatim", func() {
+				Expect(NewComponent().GenerateBase(opts)).To(Succeed())
+
+				for _, tc := range []struct {
+					writtenPath   string
+					embeddedFS    interface{ ReadFile(string) ([]byte, error) }
+					embeddedEntry string
+				}{
+					{
+						writtenPath:   "/repo/.github/actions/glk/action.yaml",
+						embeddedFS:    dotgithub.DotGitHubActions,
+						embeddedEntry: "actions/glk/action.yaml",
+					},
+					{
+						writtenPath:   "/repo/.github/workflows/glk.yaml",
+						embeddedFS:    dotgithub.DotGitHubWorkflows,
+						embeddedEntry: "workflows/glk.yaml",
+					},
+				} {
+					written, err := memFs.ReadFile(tc.writtenPath)
+					Expect(err).NotTo(HaveOccurred(), "reading %s", tc.writtenPath)
+
+					embedded, err := tc.embeddedFS.ReadFile(tc.embeddedEntry)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(bytes.HasPrefix(written, []byte(DisclaimerHeader))).To(BeTrue(), "expected %s to start with the disclaimer header", tc.writtenPath)
+					Expect(bytes.TrimPrefix(written, []byte(DisclaimerHeader))).To(Equal(embedded), "bytes after disclaimer in %s must equal embedded source byte-for-byte", tc.writtenPath)
+				}
+			})
+
+			It("preserves GitHub Actions ${{ ... }} expressions verbatim", func() {
+				Expect(NewComponent().GenerateBase(opts)).To(Succeed())
+
+				for _, tc := range []struct {
+					writtenPath   string
+					embeddedFS    interface{ ReadFile(string) ([]byte, error) }
+					embeddedEntry string
+				}{
+					{"/repo/.github/actions/glk/action.yaml", dotgithub.DotGitHubActions, "actions/glk/action.yaml"},
+					{"/repo/.github/workflows/glk.yaml", dotgithub.DotGitHubWorkflows, "workflows/glk.yaml"},
+				} {
+					written, err := memFs.ReadFile(tc.writtenPath)
+					Expect(err).NotTo(HaveOccurred())
+
+					embedded, err := tc.embeddedFS.ReadFile(tc.embeddedEntry)
+					Expect(err).NotTo(HaveOccurred())
+
+					for _, marker := range extractGitHubExpressions(string(embedded)) {
+						Expect(string(written)).To(ContainSubstring(marker), "expected %q to be preserved in %s", marker, tc.writtenPath)
+					}
+				}
+			})
+
+			It("overwrites pre-existing user content", func() {
+				const userContent = "# user-edited content that should be wiped\n"
+				Expect(memFs.MkdirAll("/repo/.github/actions/glk", 0700)).To(Succeed())
+				Expect(memFs.WriteFile("/repo/.github/actions/glk/action.yaml", []byte(userContent), 0600)).To(Succeed())
+
+				Expect(NewComponent().GenerateBase(opts)).To(Succeed())
+
+				written, err := memFs.ReadFile("/repo/.github/actions/glk/action.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(written)).NotTo(ContainSubstring("user-edited"))
+				Expect(bytes.HasPrefix(written, []byte(DisclaimerHeader))).To(BeTrue())
+			})
+		})
+
+		Context("with repositories.base.target = './base' (leading dot-slash)", func() {
+			It("writes files at the same location as 'base' without the leading dot-slash", func() {
+				generateOpts.TargetDirPath = "/repo"
+				generateOpts.Config.Repositories = &v1alpha1.RepositoriesConfig{
+					Base: &v1alpha1.BaseRepositoryConfig{Target: "./base"},
+				}
+				v1alpha1.SetObjectDefaults_LandscapeKitConfiguration(generateOpts.Config)
+
+				opts, err := components.NewOptions(generateOpts, memFs)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(NewComponent().GenerateBase(opts)).To(Succeed())
+
+				for _, p := range []string{
+					"/repo/.github/actions/glk/action.yaml",
+					"/repo/.github/workflows/glk.yaml",
+				} {
+					exists, err := memFs.Exists(p)
+					Expect(err).NotTo(HaveOccurred(), "checking existence of %s", p)
+					Expect(exists).To(BeTrue(), "expected %s to exist", p)
+				}
+			})
+		})
+	})
+
+	Describe("#GenerateLandscape", func() {
+		Context("with repositories.landscape.target = './landscapes/test' (two-level deep)", func() {
+			var opts components.LandscapeOptions
+
+			BeforeEach(func() {
+				generateOpts.TargetDirPath = "/repo"
+				generateOpts.Config.Repositories = &v1alpha1.RepositoriesConfig{
+					Landscape: &v1alpha1.LandscapeRepositoryConfig{
+						URL:    "https://github.com/gardener/gardener-ref-landscape",
+						Target: "./landscapes/test",
+					},
+				}
+				v1alpha1.SetObjectDefaults_LandscapeKitConfiguration(generateOpts.Config)
+
+				var err error
+				opts, err = components.NewLandscapeOptions(generateOpts, memFs)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("writes both .github files two levels up at the repository root", func() {
+				Expect(NewComponent().GenerateLandscape(opts)).To(Succeed())
+
+				for _, p := range []string{
+					"/repo/.github/actions/glk/action.yaml",
+					"/repo/.github/workflows/glk.yaml",
+				} {
+					exists, err := memFs.Exists(p)
+					Expect(err).NotTo(HaveOccurred(), "checking existence of %s", p)
+					Expect(exists).To(BeTrue(), "expected %s to exist", p)
+				}
+			})
+
+			It("writes only the expected subdirectories under .github/", func() {
+				Expect(NewComponent().GenerateLandscape(opts)).To(Succeed())
+
+				dirEntries, err := afero.ReadDir(memFs, "/repo/.github")
+				Expect(err).NotTo(HaveOccurred())
+
+				names := make([]string, 0, len(dirEntries))
+				for _, e := range dirEntries {
+					names = append(names, e.Name())
+				}
+				Expect(names).To(ConsistOf("actions", "workflows"))
+			})
+
+			It("does not create a .glk shadow tree under the landscape directory", func() {
+				Expect(NewComponent().GenerateLandscape(opts)).To(Succeed())
+
+				exists, err := memFs.DirExists("/repo/landscapes/test/.glk")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exists).To(BeFalse(), "github component must not write a .glk/defaults shadow tree")
+			})
+
+			It("prepends the disclaimer header and preserves the embedded bytes verbatim", func() {
+				Expect(NewComponent().GenerateLandscape(opts)).To(Succeed())
+
+				for _, tc := range []struct {
+					writtenPath   string
+					embeddedFS    interface{ ReadFile(string) ([]byte, error) }
+					embeddedEntry string
+				}{
+					{"/repo/.github/actions/glk/action.yaml", dotgithub.DotGitHubActions, "actions/glk/action.yaml"},
+					{"/repo/.github/workflows/glk.yaml", dotgithub.DotGitHubWorkflows, "workflows/glk.yaml"},
+				} {
+					written, err := memFs.ReadFile(tc.writtenPath)
+					Expect(err).NotTo(HaveOccurred())
+
+					embedded, err := tc.embeddedFS.ReadFile(tc.embeddedEntry)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(bytes.HasPrefix(written, []byte(DisclaimerHeader))).To(BeTrue(), "expected %s to start with the disclaimer header", tc.writtenPath)
+					Expect(bytes.TrimPrefix(written, []byte(DisclaimerHeader))).To(Equal(embedded), "bytes after disclaimer in %s must equal embedded source byte-for-byte", tc.writtenPath)
+				}
+			})
+		})
+	})
+})
+
+// extractGitHubExpressions returns all unique "${{ ... }}" substrings found in s.
+// These are GitHub Actions expression markers that must survive verbatim through
+// the write pipeline (no Go template rendering must occur).
+func extractGitHubExpressions(s string) []string {
+	var result []string
+	seen := make(map[string]bool)
+	for {
+		start := strings.Index(s, "${{")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(s[start:], "}}")
+		if end < 0 {
+			break
+		}
+		marker := s[start : start+end+2]
+		if !seen[marker] {
+			seen[marker] = true
+			result = append(result, marker)
+		}
+		s = s[start+end+2:]
+	}
+	return result
+}

--- a/pkg/components/github/github_suite_test.go
+++ b/pkg/components/github/github_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package github_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGitHub(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Components GitHub Suite")
+}

--- a/pkg/registry/register.go
+++ b/pkg/registry/register.go
@@ -33,12 +33,14 @@ import (
 	"github.com/gardener/gardener-landscape-kit/pkg/components/gardener/garden"
 	"github.com/gardener/gardener-landscape-kit/pkg/components/gardener/operator"
 	virtualgardenaccess "github.com/gardener/gardener-landscape-kit/pkg/components/gardener/virtual-garden-access"
+	githubcomponent "github.com/gardener/gardener-landscape-kit/pkg/components/github"
 	gardenconfig "github.com/gardener/gardener-landscape-kit/pkg/components/virtual-garden/garden-config"
 )
 
 // ComponentList contains all available components.
 var ComponentList = []func() components.Interface{
 	flux.NewComponent,
+	githubcomponent.NewComponent,
 	operator.NewComponent,
 	garden.NewComponent,
 	calico.NewComponent,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
For other GitHub instances, referring to the GitHub Actions and Workflows stored in this repository is not possible.

With this new `github` component, the respective files are created and updated by the glk.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add `github` component to maintain GitHub Actions and Workflows.
```
