### PR TITLE
Fix component override collection with new repositories path links

### DIFF
--- a/pkg/components/types.go
+++ b/pkg/components/types.go
@@ -114,41 +114,23 @@ func (o *options) GetMergeMode() configv1alpha1.MergeMode {
 	return o.mergeMode
 }
 
-// NewOptions returns a new Options instance.
+// NewOptions returns a new Options instance for `glk generate base`.
 //
-// opts.TargetDirPath is treated as the on-disk root of the repository the caller is generating into.
-// The component target directory is repoRoot/<base.target>.
-// For landscape generation, NewLandscapeOptions overrides this to repoRoot/<landscape.target>.
+// opts.TargetDirPath is treated as the on-disk root of the base repository being generated into.
+// The component target directory is repoRoot/<base.target>, which is also where the base components.yaml override is read from.
+// For landscape generation, NewLandscapeOptions overrides this with landscape-specific paths.
 func NewOptions(opts *generateoptions.Options, fs afero.Afero) (Options, error) {
 	repoRoot := path.Clean(opts.TargetDirPath)
+	targetPath := path.Join(repoRoot, opts.Config.Repositories.Base.Target)
 
-	baseTarget := opts.Config.Repositories.Base.Target
-	targetPath := path.Clean(path.Join(repoRoot, baseTarget))
-
-	var customComponentVectors [][]byte
-	if opts.Config.Repositories.Landscape != nil {
-		// Locate the base components.yaml inside the landscape repository.
-		// landscape.BaseLink is the full landscape-side path to the base content (i.e. the directory containing components dir).
-		landscape := opts.Config.Repositories.Landscape
-		baseCompVectorFile := path.Join(repoRoot, landscape.BaseLink, utilscomponentvector.ComponentVectorFilename)
-		componentsBytes, err := readCustomComponentsFile(opts, fs, baseCompVectorFile)
-		if err != nil {
-			return nil, err
-		}
-		customComponentVectors = append(customComponentVectors, componentsBytes)
-	}
-
-	componentsBytes, err := readCustomComponentsFile(opts, fs, path.Join(targetPath, utilscomponentvector.ComponentVectorFilename))
+	componentVector, err := loadComponentVector(opts, fs, path.Join(targetPath, utilscomponentvector.ComponentVectorFilename))
 	if err != nil {
 		return nil, err
 	}
-	customComponentVectors = append(customComponentVectors, componentsBytes)
+	return newOptions(opts, fs, repoRoot, targetPath, componentVector), nil
+}
 
-	componentVector, err := utilscomponentvector.NewWithOverride(componentvector.DefaultComponentsYAML, customComponentVectors...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create component vector: %w", err)
-	}
-
+func newOptions(opts *generateoptions.Options, fs afero.Afero, repoRoot, targetPath string, componentVector utilscomponentvector.Interface) *options {
 	return &options{
 		componentVector: componentVector,
 		repoRoot:        repoRoot,
@@ -156,7 +138,24 @@ func NewOptions(opts *generateoptions.Options, fs afero.Afero) (Options, error) 
 		filesystem:      fs,
 		logger:          opts.Log,
 		mergeMode:       *opts.Config.MergeMode,
-	}, nil
+	}
+}
+
+// loadComponentVector reads zero or more components.yaml override files (later paths override earlier ones) on top of the default component vector embedded in the binary.
+func loadComponentVector(opts *generateoptions.Options, fs afero.Afero, overridePaths ...string) (utilscomponentvector.Interface, error) {
+	var customComponentVectors [][]byte
+	for _, p := range overridePaths {
+		componentsBytes, err := readCustomComponentsFile(opts, fs, p)
+		if err != nil {
+			return nil, err
+		}
+		customComponentVectors = append(customComponentVectors, componentsBytes)
+	}
+	componentVector, err := utilscomponentvector.NewWithOverride(componentvector.DefaultComponentsYAML, customComponentVectors...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create component vector: %w", err)
+	}
+	return componentVector, nil
 }
 
 func readCustomComponentsFile(opts *generateoptions.Options, fs afero.Afero, filePath string) ([]byte, error) {
@@ -221,17 +220,29 @@ func (l *landscapeOptions) GetRelativeBaseComponentPath(componentDir string) str
 }
 
 // NewLandscapeOptions returns a new LandscapeOptions instance.
+//
+// opts.TargetDirPath is the on-disk root of the landscape repository.
+// Both the base and the landscape components.yaml override files are read from inside this repository:
+// the former at landscape.baseLink (where the base content is mounted), the latter at landscape.target.
+// The landscape override is applied last so it takes precedence.
 func NewLandscapeOptions(opts *generateoptions.Options, fs afero.Afero) (LandscapeOptions, error) {
-	base, err := NewOptions(opts, fs)
+	repoRoot := path.Clean(opts.TargetDirPath)
+	landscape := opts.Config.Repositories.Landscape
+
+	componentVector, err := loadComponentVector(opts, fs,
+		// Base components.yaml override, mounted inside the landscape repo at landscape.baseLink.
+		path.Join(repoRoot, landscape.BaseLink, utilscomponentvector.ComponentVectorFilename),
+		// Landscape-specific components.yaml override.
+		path.Join(repoRoot, landscape.Target, utilscomponentvector.ComponentVectorFilename),
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	landscape := opts.Config.Repositories.Landscape
-
+	basePath := path.Join(repoRoot, landscape.BaseLink)
 	return &landscapeOptions{
-		Options:    base,
+		Options:    newOptions(opts, fs, repoRoot, basePath, componentVector),
 		landscape:  landscape,
-		targetPath: path.Clean(path.Join(base.GetRepoRoot(), landscape.Target)),
+		targetPath: path.Clean(path.Join(repoRoot, landscape.Target)),
 	}, nil
 }

--- a/pkg/components/types_test.go
+++ b/pkg/components/types_test.go
@@ -326,6 +326,41 @@ var _ = Describe("Types", func() {
 				Expect(result.GetRelativeBasePath()).To(Equal("base"))
 				Expect(result.GetRelativeLandscapePath()).To(Equal("landscape"))
 			})
+
+			It("should collect both the base and landscape components.yaml overrides with the landscape one taking precedence", func() {
+				opts.TargetDirPath = "/path/to/target"
+				opts.Config.Repositories.Landscape.BaseLink = "./baseDir"
+				opts.Config.Repositories.Landscape.Target = "./landscapeDir"
+
+				baseVectorYAML := `components:
+- name: github.com/gardener/gardener
+  sourceRepository: https://github.com/gardener/gardener
+  version: v1.100.0
+- name: github.com/gardener/gardener-extension-networking-cilium
+  sourceRepository: https://github.com/gardener/gardener-extension-networking-cilium
+  version: v1.45.0
+`
+				landscapeVectorYAML := `components:
+- name: github.com/gardener/gardener
+  sourceRepository: https://github.com/gardener/gardener
+  version: v1.200.0
+`
+				Expect(fs.WriteFile("/path/to/target/baseDir/components.yaml", []byte(baseVectorYAML), 0644)).To(Succeed())
+				Expect(fs.WriteFile("/path/to/target/landscapeDir/components.yaml", []byte(landscapeVectorYAML), 0644)).To(Succeed())
+
+				landscapeOpts, err := NewLandscapeOptions(opts, fs)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Landscape override wins for the shared component.
+				gardenerVersion, exists := landscapeOpts.GetComponentVector().FindComponentVersion("github.com/gardener/gardener")
+				Expect(exists).To(BeTrue())
+				Expect(gardenerVersion).To(Equal("v1.200.0"))
+
+				// Base override is still applied for components not present in the landscape override.
+				ciliumVersion, exists := landscapeOpts.GetComponentVector().FindComponentVersion("github.com/gardener/gardener-extension-networking-cilium")
+				Expect(exists).To(BeTrue())
+				Expect(ciliumVersion).To(Equal("v1.45.0"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Base `components.yaml` was collected twice, landscape one ignored.

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
