### PR TITLE
Resolve relativeOciReference against repository host instead of full URL

### DIFF
--- a/docs/usage/ocm/relative-oci-reference.md
+++ b/docs/usage/ocm/relative-oci-reference.md
@@ -28,20 +28,18 @@ The `reference` field must contain a path with a tag (`name:tag`), a digest (`na
 
 ## Resolution
 
-When GLK looks up a component version it remembers the URL of the repository the descriptor was found in. While extracting resources from the descriptor, every `relativeOciReference` access is resolved into a fully-qualified image reference using the rule:
+When GLK looks up a component version it remembers the host of the repository the descriptor was found in. While extracting resources from the descriptor, every `relativeOciReference` access is resolved into a fully-qualified image reference using the rule:
 
 ```
-<repository-url-without-scheme> + "/" + <reference>
+<repository-host> + "/" + <reference>
 ```
 
-The repository URL is normalized first:
-- the URL scheme (`https://`, `http://`) is stripped
-- a trailing `/` is removed
+The repository host is the hostname (with optional port) parsed from the repository URL — the scheme and any path are dropped.
 
 A leading `/` on the relative reference is also stripped to avoid producing a double slash. As a concrete example, given:
 
 - repository URL: `https://registry.example.com/path/to/repo/`
-- relative reference: `img/sub-path:v0.0.1@sha256:deadbeef`
+- relative reference: `path/to/repo/img/sub-path:v0.0.1@sha256:deadbeef`
 
 the resolved image reference becomes:
 
@@ -56,8 +54,8 @@ If the resource access is still in raw (unparsed) form when GLK encounters it, G
 ## Where this is wired up
 
 - The custom type is declared in [`pkg/ocm/ociaccess/relativeocireference.go`](../../../pkg/ocm/ociaccess/relativeocireference.go) and registered with the OCM runtime scheme in [`pkg/ocm/ociaccess/repoaccess.go`](../../../pkg/ocm/ociaccess/repoaccess.go).
-- The resolution against the repository URL is performed by `extractImageReference` in [`pkg/ocm/components/components.go`](../../../pkg/ocm/components/components.go), which is called from both the OCI image extraction path and the Helm chart extraction path.
-- The repository URL used as the base is captured by `FindComponentVersion` in [`pkg/ocm/ociaccess/repoaccess.go`](../../../pkg/ocm/ociaccess/repoaccess.go) and returned in `FindComponentVersionResult.RepositoryURL` (already normalized via `trimURLScheme`).
+- The resolution against the repository host is performed by `extractImageReference` in [`pkg/ocm/components/components.go`](../../../pkg/ocm/components/components.go), which is called from both the OCI image extraction path and the Helm chart extraction path.
+- The repository host used as the base is captured by `FindComponentVersion` in [`pkg/ocm/ociaccess/repoaccess.go`](../../../pkg/ocm/ociaccess/repoaccess.go) and returned in `FindComponentVersionResult.RepositoryHost` (extracted from the repository URL via `hostFromURL`).
 
 ## Compatibility note
 

--- a/pkg/ocm/components/components.go
+++ b/pkg/ocm/components/components.go
@@ -698,7 +698,7 @@ func rawToImageSources(value json.RawMessage) ([]*ocmimagevector.ExtendedImageSo
 	return obj.Images, nil
 }
 
-func resourceToImageSource(res descriptorruntime.Resource, repoPrefix string) (*ocmimagevector.ExtendedImageSource, error) {
+func resourceToImageSource(res descriptorruntime.Resource, repoHost string) (*ocmimagevector.ExtendedImageSource, error) {
 	if res.Type != ResourceTypeOCIImage {
 		return nil, nil
 	}
@@ -733,7 +733,7 @@ func resourceToImageSource(res descriptorruntime.Resource, repoPrefix string) (*
 		src.Name = res.Name
 		src.LookupOnly = true
 	}
-	imageReference, err := extractImageReference(res, repoPrefix)
+	imageReference, err := extractImageReference(res, repoHost)
 	if err != nil {
 		return nil, err
 	}
@@ -751,12 +751,12 @@ func resourceToImageSource(res descriptorruntime.Resource, repoPrefix string) (*
 	return &src, nil
 }
 
-func extractImageReference(res descriptorruntime.Resource, repoPrefix string) (string, error) {
+func extractImageReference(res descriptorruntime.Resource, repoHost string) (string, error) {
 	var imageReference string
 	switch a := res.Access.(type) {
 	case *ociaccess.RelativeOciReference:
 		// Relative OCI references carry only a sub-path; prepend the component's repository host to form a fully-qualified image reference.
-		imageReference = strings.TrimRight(repoPrefix, "/") + "/" + strings.TrimLeft(a.Reference, "/")
+		imageReference = strings.TrimRight(repoHost, "/") + "/" + strings.TrimLeft(a.Reference, "/")
 	case *accessv1.OCIImage:
 		imageReference = a.ImageReference
 	default:
@@ -770,7 +770,7 @@ func extractImageReference(res descriptorruntime.Resource, repoPrefix string) (s
 		}
 		switch c := converted.(type) {
 		case *ociaccess.RelativeOciReference:
-			imageReference = strings.TrimRight(repoPrefix, "/") + "/" + strings.TrimLeft(c.Reference, "/")
+			imageReference = strings.TrimRight(repoHost, "/") + "/" + strings.TrimLeft(c.Reference, "/")
 		case *accessv1.OCIImage:
 			imageReference = c.ImageReference
 		default:

--- a/pkg/ocm/components/components.go
+++ b/pkg/ocm/components/components.go
@@ -155,7 +155,7 @@ func (c *Components) addComponent(result *ociaccess.FindComponentVersionResult) 
 func (c *Components) extractImageVectorFromResources(result *ociaccess.FindComponentVersionResult) ([]ocmimagevector.ExtendedImageSource, error) {
 	var vector []ocmimagevector.ExtendedImageSource
 	for _, res := range result.Descriptor.Component.Resources {
-		src, err := resourceToImageSource(res, result.RepositoryURL)
+		src, err := resourceToImageSource(res, result.RepositoryHost)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert resource %s to image source: %w", res.Name, err)
 		}
@@ -171,7 +171,7 @@ func (c *Components) extractResourcesFromDescriptor(result *ociaccess.FindCompon
 	for _, res := range result.Descriptor.Component.Resources {
 		switch res.Type {
 		case ResourceTypeOCIImage:
-			src, err := resourceToImageSource(res, result.RepositoryURL)
+			src, err := resourceToImageSource(res, result.RepositoryHost)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert resource %s to image source: %w", res.Name, err)
 			}
@@ -201,7 +201,7 @@ func (c *Components) extractResourcesFromDescriptor(result *ociaccess.FindCompon
 				resources = append(resources, resource)
 			}
 		case ResourceTypeHelmChart:
-			imageReference, err := extractImageReference(res, result.RepositoryURL)
+			imageReference, err := extractImageReference(res, result.RepositoryHost)
 			if err != nil {
 				return nil, err
 			}
@@ -698,7 +698,7 @@ func rawToImageSources(value json.RawMessage) ([]*ocmimagevector.ExtendedImageSo
 	return obj.Images, nil
 }
 
-func resourceToImageSource(res descriptorruntime.Resource, repoURL string) (*ocmimagevector.ExtendedImageSource, error) {
+func resourceToImageSource(res descriptorruntime.Resource, repoPrefix string) (*ocmimagevector.ExtendedImageSource, error) {
 	if res.Type != ResourceTypeOCIImage {
 		return nil, nil
 	}
@@ -733,12 +733,12 @@ func resourceToImageSource(res descriptorruntime.Resource, repoURL string) (*ocm
 		src.Name = res.Name
 		src.LookupOnly = true
 	}
-	imageReference, err := extractImageReference(res, repoURL)
+	imageReference, err := extractImageReference(res, repoPrefix)
 	if err != nil {
 		return nil, err
 	}
 	src.Ref = &imageReference
-	repo, tag, err := splitRef(imageReference)
+	repo, tag, err := helpers.SplitOCIImageReference(imageReference)
 	if err != nil {
 		return nil, fmt.Errorf("failed to split ref %s: %w", imageReference, err)
 	}
@@ -751,12 +751,12 @@ func resourceToImageSource(res descriptorruntime.Resource, repoURL string) (*ocm
 	return &src, nil
 }
 
-func extractImageReference(res descriptorruntime.Resource, repoURL string) (string, error) {
+func extractImageReference(res descriptorruntime.Resource, repoPrefix string) (string, error) {
 	var imageReference string
 	switch a := res.Access.(type) {
 	case *ociaccess.RelativeOciReference:
-		// Relative OCI references carry only a sub-path; prepend the component's repository URL to form a fully-qualified image reference.
-		imageReference = strings.TrimRight(repoURL, "/") + "/" + strings.TrimLeft(a.Reference, "/")
+		// Relative OCI references carry only a sub-path; prepend the component's repository host to form a fully-qualified image reference.
+		imageReference = strings.TrimRight(repoPrefix, "/") + "/" + strings.TrimLeft(a.Reference, "/")
 	case *accessv1.OCIImage:
 		imageReference = a.ImageReference
 	default:
@@ -770,7 +770,7 @@ func extractImageReference(res descriptorruntime.Resource, repoURL string) (stri
 		}
 		switch c := converted.(type) {
 		case *ociaccess.RelativeOciReference:
-			imageReference = strings.TrimRight(repoURL, "/") + "/" + strings.TrimLeft(c.Reference, "/")
+			imageReference = strings.TrimRight(repoPrefix, "/") + "/" + strings.TrimLeft(c.Reference, "/")
 		case *accessv1.OCIImage:
 			imageReference = c.ImageReference
 		default:
@@ -778,22 +778,6 @@ func extractImageReference(res descriptorruntime.Resource, repoURL string) (stri
 		}
 	}
 	return imageReference, nil
-}
-
-func splitRef(ref string) (string, string, error) {
-	parts1 := strings.SplitN(ref, ":", 2)
-	parts2 := strings.SplitN(ref, "@", 2)
-	var parts []string
-	if len(parts1) == 2 {
-		parts = parts1
-	}
-	if len(parts2) == 2 && len(parts) == 2 && len(parts2[1]) > len(parts[1]) {
-		parts = parts2
-	}
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid reference format")
-	}
-	return parts[0], parts[1], nil
 }
 
 func toString(value json.RawMessage) (string, error) {

--- a/pkg/ocm/components/components_test.go
+++ b/pkg/ocm/components/components_test.go
@@ -489,11 +489,11 @@ scheduler:
 		Expect(c.GetSortedComponents()).To(ContainElements(ComponentReference("github.com/gardener/diki:v0.25.0")))
 	})
 
-	It("should resolve relativeOciReference resources against the repository URL", func() {
+	It("should resolve relativeOciReference resources against the repository host", func() {
 		desc := buildRelativeOciDescriptor("example.com/comp-with-relative-ref", "v0.0.1", ResourceTypeOCIImage, "my-image", "v0.0.1", "img/sub-path:v0.0.1@sha256:deadbeef")
 		_, err := c.AddComponentDependencies(&ociaccess.FindComponentVersionResult{
-			Descriptor:    desc,
-			RepositoryURL: "registry.example.com/path/to/repo",
+			Descriptor:     desc,
+			RepositoryHost: "registry.example.com:443",
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -502,7 +502,7 @@ scheduler:
 		Expect(err).NotTo(HaveOccurred())
 		Expect(imageVector).To(ConsistOf(imagevector.ImageSource{
 			Name:       "my-image",
-			Repository: new("registry.example.com/path/to/repo/img/sub-path"),
+			Repository: new("registry.example.com:443/img/sub-path"),
 			Tag:        new("v0.0.1@sha256:deadbeef"),
 			Version:    new("v0.0.1"),
 		}))
@@ -511,18 +511,18 @@ scheduler:
 	It("should fail for malformed relativeOciReference resources", func() {
 		desc := buildRelativeOciDescriptor("example.com/comp-with-relative-ref", "v0.0.1", ResourceTypeOCIImage, "my-image", "v0.0.1", "no-tag-no-digest")
 		_, err := c.AddComponentDependencies(&ociaccess.FindComponentVersionResult{
-			Descriptor:    desc,
-			RepositoryURL: "registry.example.com/path/to/repo",
+			Descriptor:     desc,
+			RepositoryHost: "registry.example.com:443",
 		})
 		Expect(err).To(MatchError(ContainSubstring("failed to convert resource my-image to image source")))
-		Expect(err).To(MatchError(ContainSubstring("invalid reference format")))
+		Expect(err).To(MatchError(ContainSubstring("unexpected reference")))
 	})
 
-	It("should resolve relativeOciReference helmChart resources against the repository URL", func() {
+	It("should resolve relativeOciReference helmChart resources against the repository host", func() {
 		desc := buildRelativeOciDescriptor("example.com/comp-with-relative-helm-ref", "v0.0.1", ResourceTypeHelmChart, "my-chart", "v0.0.1", "charts/my-chart:v0.0.1@sha256:deadbeef")
 		_, err := c.AddComponentDependencies(&ociaccess.FindComponentVersionResult{
-			Descriptor:    desc,
-			RepositoryURL: "registry.example.com/path/to/repo",
+			Descriptor:     desc,
+			RepositoryHost: "registry.example.com:443",
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -531,7 +531,7 @@ scheduler:
 			Name:    "my-chart",
 			Version: "v0.0.1",
 			Type:    ResourceTypeHelmChart,
-			Value:   "registry.example.com/path/to/repo/charts/my-chart:v0.0.1@sha256:deadbeef",
+			Value:   "registry.example.com:443/charts/my-chart:v0.0.1@sha256:deadbeef",
 		}))
 	})
 })
@@ -567,7 +567,7 @@ var _ = Describe("#resourceToImageSource", func() {
 	}
 
 	DescribeTable("resolves the image reference",
-		func(accessType, accessRef, repoURL, expectedRef, expectedRepo, expectedTag string) {
+		func(accessType, accessRef, repoPrefix, expectedRef, expectedRepo, expectedTag string) {
 			for _, raw := range []bool{true, false} {
 				res := descriptorruntime.Resource{
 					Type:   ResourceTypeOCIImage,
@@ -576,7 +576,7 @@ var _ = Describe("#resourceToImageSource", func() {
 				res.Name = "my-image"
 				res.Version = "1.2.3"
 
-				src, err := resourceToImageSource(res, repoURL)
+				src, err := resourceToImageSource(res, repoPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(src).NotTo(BeNil())
 				Expect(*src.Ref).To(Equal(expectedRef))
@@ -591,23 +591,23 @@ var _ = Describe("#resourceToImageSource", func() {
 			"registry.example.com/my-image",
 			"1.2.3",
 		),
-		Entry("relative reference with tag, repoURL prepended",
-			ociaccess.RelativeOciReferenceTypeName, "my-image:1.2.3",
-			"registry.example.com/path",
+		Entry("relative reference with tag, repoPrefix prepended",
+			ociaccess.RelativeOciReferenceTypeName, "path/my-image:1.2.3",
+			"registry.example.com",
 			"registry.example.com/path/my-image:1.2.3",
 			"registry.example.com/path/my-image",
 			"1.2.3",
 		),
-		Entry("relative reference with digest, repoURL prepended",
-			ociaccess.RelativeOciReferenceTypeName, "my-image@sha256:abc",
-			"registry.example.com/path",
+		Entry("relative reference with digest, repoPrefix prepended",
+			ociaccess.RelativeOciReferenceTypeName, "path/my-image@sha256:abc",
+			"registry.example.com",
 			"registry.example.com/path/my-image@sha256:abc",
 			"registry.example.com/path/my-image",
 			"sha256:abc",
 		),
-		Entry("relative reference with leading slash and repoURL with trailing slash, no double slash",
-			ociaccess.RelativeOciReferenceTypeName, "/my-image:1.2.3",
-			"registry.example.com/path/",
+		Entry("relative reference with leading slash, no double slash",
+			ociaccess.RelativeOciReferenceTypeName, "/path/my-image:1.2.3",
+			"registry.example.com",
 			"registry.example.com/path/my-image:1.2.3",
 			"registry.example.com/path/my-image",
 			"1.2.3",
@@ -654,9 +654,9 @@ func loadWithDepRecursive(c *Components, loadDescriptor func(cref ComponentRefer
 		desc := loadDescriptor(root)
 		blobs := addFakeLocalBlobs(desc)
 		deps, err := c.AddComponentDependencies(&ociaccess.FindComponentVersionResult{
-			Descriptor:    desc,
-			LocalBlobs:    blobs,
-			RepositoryURL: "registry.example.com/path/to/repo",
+			Descriptor:     desc,
+			LocalBlobs:     blobs,
+			RepositoryHost: "registry.example.com:443",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		if levels > 0 && len(deps) > 0 {

--- a/pkg/ocm/components/components_test.go
+++ b/pkg/ocm/components/components_test.go
@@ -567,7 +567,7 @@ var _ = Describe("#resourceToImageSource", func() {
 	}
 
 	DescribeTable("resolves the image reference",
-		func(accessType, accessRef, repoPrefix, expectedRef, expectedRepo, expectedTag string) {
+		func(accessType, accessRef, repoHost, expectedRef, expectedRepo, expectedTag string) {
 			for _, raw := range []bool{true, false} {
 				res := descriptorruntime.Resource{
 					Type:   ResourceTypeOCIImage,
@@ -576,7 +576,7 @@ var _ = Describe("#resourceToImageSource", func() {
 				res.Name = "my-image"
 				res.Version = "1.2.3"
 
-				src, err := resourceToImageSource(res, repoPrefix)
+				src, err := resourceToImageSource(res, repoHost)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(src).NotTo(BeNil())
 				Expect(*src.Ref).To(Equal(expectedRef))
@@ -591,14 +591,14 @@ var _ = Describe("#resourceToImageSource", func() {
 			"registry.example.com/my-image",
 			"1.2.3",
 		),
-		Entry("relative reference with tag, repoPrefix prepended",
+		Entry("relative reference with tag, repoHost prepended",
 			ociaccess.RelativeOciReferenceTypeName, "path/my-image:1.2.3",
 			"registry.example.com",
 			"registry.example.com/path/my-image:1.2.3",
 			"registry.example.com/path/my-image",
 			"1.2.3",
 		),
-		Entry("relative reference with digest, repoPrefix prepended",
+		Entry("relative reference with digest, repoHost prepended",
 			ociaccess.RelativeOciReferenceTypeName, "path/my-image@sha256:abc",
 			"registry.example.com",
 			"registry.example.com/path/my-image@sha256:abc",

--- a/pkg/ocm/ociaccess/repoaccess.go
+++ b/pkg/ocm/ociaccess/repoaccess.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"strings"
@@ -125,9 +126,8 @@ type FindComponentVersionResult struct {
 	// LocalBlobs holds the bytes of any local-blob resources requested via localBlobResourceTypes,
 	// keyed by name/version/type. Nil if none were requested or found.
 	LocalBlobs LocalBlobs
-	// RepositoryURL is the normalized URL (no scheme, no trailing slash)
-	// of the repository where the component was found.
-	RepositoryURL string
+	// RepositoryHost is host of the repository where the component was found.
+	RepositoryHost string
 }
 
 // FindComponentVersion searches for a specific component version across multiple repositories.
@@ -150,10 +150,14 @@ func FindComponentVersion(
 			if err != nil {
 				return nil, fmt.Errorf("failed to load local blobs for component version %s:%s from repository %s: %w", component, version, repo.RepositoryURL, err)
 			}
+			host, err := hostFromURL(repo.RepositoryURL)
+			if err != nil {
+				return nil, err
+			}
 			return &FindComponentVersionResult{
-				Descriptor:    descriptor,
-				LocalBlobs:    repoLocalBlobs,
-				RepositoryURL: trimURLScheme(repo.RepositoryURL),
+				Descriptor:     descriptor,
+				LocalBlobs:     repoLocalBlobs,
+				RepositoryHost: host,
 			}, nil
 		}
 		errs = append(errs, fmt.Errorf("repository %s: %w", repo.RepositoryURL, err))
@@ -170,12 +174,15 @@ type NameVersionType struct {
 	Type    string
 }
 
-func trimURLScheme(repoURL string) string {
-	repoURL = strings.TrimSuffix(repoURL, "/")
-	if idx := strings.Index(repoURL, "://"); idx > 0 {
-		repoURL = repoURL[idx+3:]
+func hostFromURL(repoURL string) (string, error) {
+	u, err := url.ParseRequestURI(repoURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract hostname from repository URL %q: %w", repoURL, err)
 	}
-	return repoURL
+	if u.Host == "" {
+		return "", fmt.Errorf("repository URL %q has no host", repoURL)
+	}
+	return u.Host, nil
 }
 
 func loadLocalBlobs(ctx context.Context, repo *RepoAccess, descriptor *descriptorruntime.Descriptor, localBlobResourceTypes ...string) (map[NameVersionType][]byte, error) {

--- a/pkg/ocm/ociaccess/repoaccess_test.go
+++ b/pkg/ocm/ociaccess/repoaccess_test.go
@@ -10,18 +10,24 @@ import (
 )
 
 var _ = Describe("RepoAccess", func() {
-	DescribeTable("#trimURLScheme",
-		func(input, expected string) {
-			Expect(trimURLScheme(input)).To(Equal(expected))
+	DescribeTable("#hostFromURL",
+		func(input, expectedHost string, expectErr bool) {
+			host, err := hostFromURL(input)
+			if expectErr {
+				Expect(err).To(HaveOccurred())
+				Expect(host).To(BeEmpty())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(host).To(Equal(expectedHost))
 		},
-		Entry("empty", "", ""),
-		Entry("no scheme no slash", "registry.example.com/path", "registry.example.com/path"),
-		Entry("https scheme", "https://registry.example.com/path", "registry.example.com/path"),
-		Entry("http scheme", "http://registry.example.com/path", "registry.example.com/path"),
-		Entry("trailing slash", "registry.example.com/path/", "registry.example.com/path"),
-		Entry("scheme and trailing slash", "https://registry.example.com/path/", "registry.example.com/path"),
-		Entry("scheme only no path", "https://registry.example.com", "registry.example.com"),
-		Entry("with port", "https://registry.example.com:5000/path", "registry.example.com:5000/path"),
-		Entry("leading scheme delimiter", "://nothing", "://nothing"),
+		Entry("https scheme", "https://registry.example.com/path", "registry.example.com", false),
+		Entry("http scheme", "http://registry.example.com/path", "registry.example.com", false),
+		Entry("https with port", "https://registry.example.com:5000/path", "registry.example.com:5000", false),
+		Entry("https scheme only no path", "https://registry.example.com", "registry.example.com", false),
+		Entry("trailing slash", "https://registry.example.com/path/", "registry.example.com", false),
+		Entry("no scheme", "registry.example.com/path", "", true),
+		Entry("empty", "", "", true),
+		Entry("malformed", "://nothing", "", true),
 	)
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
Switch the base prepended to `relativeOciReference` resources from the normalized repository URL (host + path) to just the host. This seems to be the semantic used in the generated component descriptors. The full sub-path lives in the relative reference itself.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up of #355 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```

/cc @LucaBernstein 