### PR TITLE
Fix the operator component's component-vector lookup

### DIFF
--- a/pkg/components/gardener/operator/component.go
+++ b/pkg/components/gardener/operator/component.go
@@ -96,13 +96,9 @@ func getTemplateValues(opts components.Options) (map[string]any, error) {
 		}, nil
 	}
 
-	ref, err := getOCIImageReferenceFromComponentVector("operator", cv)
+	repository, tag, err := getHelmChartRepoTagFromComponentVector("operator", cv)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get operator OCI image reference from component vector: %w", err)
-	}
-	repository, tag, err := helpers.SplitOCIImageReference(ref)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get operator Helm chart repository/tag from component vector: %w", err)
 	}
 
 	values, err := cv.TemplateValues()
@@ -134,18 +130,24 @@ func writeLandscapeTemplateFiles(opts components.LandscapeOptions) error {
 	return files.WriteObjectsToFilesystem(objects, opts.GetTargetPath(), path.Join(components.DirName, ComponentDirectory), opts.GetFilesystem(), opts.GetMergeMode())
 }
 
-func getOCIImageReferenceFromComponentVector(name string, cv *utilscomponentvector.ComponentVector) (string, error) {
+func getHelmChartRepoTagFromComponentVector(name string, cv *utilscomponentvector.ComponentVector) (string, string, error) {
 	if cv == nil || len(cv.Resources) == 0 {
-		return "", fmt.Errorf("component vector or component resources are nil")
+		return "", "", fmt.Errorf("component vector or component resources are nil")
 	}
 
 	data, found := cv.Resources[name]
 	if !found {
-		return "", fmt.Errorf("no resources found for component %s", name)
+		return "", "", fmt.Errorf("no resources found for component %s", name)
 	}
-	ociImage := data.OCIImage
-	if ociImage == nil || ptr.Deref(ociImage.Ref, "") == "" {
-		return "", fmt.Errorf("OCI image reference not found for component %s", name)
+	if data.HelmChart == nil {
+		return "", "", fmt.Errorf("HelmChart not found for component %s", name)
 	}
-	return ptr.Deref(ociImage.Ref, ""), nil
+	if data.HelmChart.Repository != nil && data.HelmChart.Tag != nil {
+		return *data.HelmChart.Repository, *data.HelmChart.Tag, nil
+	}
+	ref := data.HelmChart.Ref
+	if ptr.Deref(ref, "") == "" {
+		return "", "", fmt.Errorf("HelmChart reference not found for component %s", name)
+	}
+	return helpers.SplitOCIImageReference(*ref)
 }

--- a/pkg/components/gardener/operator/testdata/expected-kustomize-ocm.yaml
+++ b/pkg/components/gardener/operator/testdata/expected-kustomize-ocm.yaml
@@ -10,7 +10,7 @@ spec:
     operation: copy
   ref:
     tag: v1.2.3
-  url: oci://test.repo/path/gardener/operator
+  url: oci://test.repo/path/charts/gardener/operator
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Fix the operator component's component-vector lookup. It was wrongly fetched from an OCI image reference path (`OCIImage.Ref`), but should be from the Helm chart path (`HelmChart.Repository/Tag/Ref`). The wrong test has also been adjusted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix: change the operator component's component-vector lookup from an OCI image reference path (`OCIImage.Ref`) to a Helm chart path (`HelmChart.Repository/Tag/Ref`).
```
