### PR TITLE
Add Flux Images as Resources

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,6 +62,12 @@ The following dependencies have been updated:\n\
       groupName: "fluxcd-controllers",
       matchPackageNames: ['/^github\\.com/fluxcd/[^/]+-controller(/.*)?$/'],
     },
+    {
+      // Flux controller OCI images are managed by hack/flux-gotk-generate.sh.
+      matchDatasources: ['docker'],
+      matchPackageNames: ['/^ghcr\\.io\\/fluxcd\\//'],
+      enabled: false,
+    },
     // The following list of dependencies is updated by `make generate` and restricts updates to type `patch`.
     // DO NOT EDIT THIS SECTION MANUALLY.
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,7 +65,7 @@ The following dependencies have been updated:\n\
     {
       // Flux controller OCI images are managed by hack/flux-gotk-generate.sh.
       matchDatasources: ['docker'],
-      matchPackageNames: ['/^ghcr\\.io\\/fluxcd\\//'],
+      matchPackageNames: ['/^ghcr\\.io\\/fluxcd\\/.+-controller$/'],
       enabled: false,
     },
     // The following list of dependencies is updated by `make generate` and restricts updates to type `patch`.

--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -6,3 +6,32 @@ main-source:
       policy: skip
       comment: |
         we use gosec for sast scanning. See attached log.
+resources:
+  - name: source-controller
+    version: v1.8.5
+    type: ociImage
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: ghcr.io/fluxcd/source-controller:v1.8.5
+  - name: kustomize-controller
+    version: v1.8.5
+    type: ociImage
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: ghcr.io/fluxcd/kustomize-controller:v1.8.5
+  - name: helm-controller
+    version: v1.5.5
+    type: ociImage
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: ghcr.io/fluxcd/helm-controller:v1.5.5
+  - name: notification-controller
+    version: v1.8.4
+    type: ociImage
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: ghcr.io/fluxcd/notification-controller:v1.8.4

--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -7,6 +7,13 @@ main-source:
         comment: |
           we use gosec for sast scanning. See attached log.
 resources:
+  - name: flux-cli
+    version: v2.8.8
+    type: ociImage
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: ghcr.io/fluxcd/flux-cli:v2.8.8
   - name: helm-controller
     version: v1.5.5
     type: ociImage

--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,26 +1,12 @@
 name: github.com/gardener/gardener-landscape-kit
 main-source:
   labels:
-  - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
-    value:
-      policy: skip
-      comment: |
-        we use gosec for sast scanning. See attached log.
+    - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
+      value:
+        policy: skip
+        comment: |
+          we use gosec for sast scanning. See attached log.
 resources:
-  - name: source-controller
-    version: v1.8.5
-    type: ociImage
-    relation: external
-    access:
-      type: ociRegistry
-      imageReference: ghcr.io/fluxcd/source-controller:v1.8.5
-  - name: kustomize-controller
-    version: v1.8.5
-    type: ociImage
-    relation: external
-    access:
-      type: ociRegistry
-      imageReference: ghcr.io/fluxcd/kustomize-controller:v1.8.5
   - name: helm-controller
     version: v1.5.5
     type: ociImage
@@ -28,6 +14,13 @@ resources:
     access:
       type: ociRegistry
       imageReference: ghcr.io/fluxcd/helm-controller:v1.5.5
+  - name: kustomize-controller
+    version: v1.8.5
+    type: ociImage
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: ghcr.io/fluxcd/kustomize-controller:v1.8.5
   - name: notification-controller
     version: v1.8.4
     type: ociImage
@@ -35,3 +28,10 @@ resources:
     access:
       type: ociRegistry
       imageReference: ghcr.io/fluxcd/notification-controller:v1.8.4
+  - name: source-controller
+    version: v1.8.5
+    type: ociImage
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: ghcr.io/fluxcd/source-controller:v1.8.5

--- a/componentvector/components.yaml
+++ b/componentvector/components.yaml
@@ -2,6 +2,23 @@ components:
 - name: github.com/gardener/gardener-landscape-kit
   sourceRepository: https://github.com/gardener/gardener-landscape-kit
   version: v0.3.0-dev
+  resources:
+    sourceController:
+      ociImage:
+        repository: ghcr.io/fluxcd/source-controller
+        tag: v1.8.5
+    kustomizeController:
+      ociImage:
+        repository: ghcr.io/fluxcd/kustomize-controller
+        tag: v1.8.5
+    helmController:
+      ociImage:
+        repository: ghcr.io/fluxcd/helm-controller
+        tag: v1.5.5
+    notificationController:
+      ociImage:
+        repository: ghcr.io/fluxcd/notification-controller
+        tag: v1.8.4
 - name: github.com/gardener/gardener
   sourceRepository: https://github.com/gardener/gardener
   version: v1.145.2

--- a/componentvector/components.yaml
+++ b/componentvector/components.yaml
@@ -3,22 +3,22 @@ components:
   sourceRepository: https://github.com/gardener/gardener-landscape-kit
   version: v0.3.0-dev
   resources:
-    sourceController:
-      ociImage:
-        repository: ghcr.io/fluxcd/source-controller
-        tag: v1.8.5
-    kustomizeController:
-      ociImage:
-        repository: ghcr.io/fluxcd/kustomize-controller
-        tag: v1.8.5
     helmController:
       ociImage:
         repository: ghcr.io/fluxcd/helm-controller
         tag: v1.5.5
+    kustomizeController:
+      ociImage:
+        repository: ghcr.io/fluxcd/kustomize-controller
+        tag: v1.8.5
     notificationController:
       ociImage:
         repository: ghcr.io/fluxcd/notification-controller
         tag: v1.8.4
+    sourceController:
+      ociImage:
+        repository: ghcr.io/fluxcd/source-controller
+        tag: v1.8.5
 - name: github.com/gardener/gardener
   sourceRepository: https://github.com/gardener/gardener
   version: v1.145.2

--- a/componentvector/components.yaml
+++ b/componentvector/components.yaml
@@ -3,6 +3,10 @@ components:
   sourceRepository: https://github.com/gardener/gardener-landscape-kit
   version: v0.3.0-dev
   resources:
+    fluxCLI:
+      ociImage:
+        repository: ghcr.io/fluxcd/flux-cli
+        tag: v2.8.8
     helmController:
       ociImage:
         repository: ghcr.io/fluxcd/helm-controller

--- a/hack/flux-gotk-generate.sh
+++ b/hack/flux-gotk-generate.sh
@@ -72,6 +72,24 @@ update_resource "kustomizeController" "$KUSTOMIZE_IMAGE"
 update_resource "helmController" "$HELM_IMAGE"
 update_resource "notificationController" "$NOTIFICATION_IMAGE"
 
+## Update Flux controller images in .ocm/base-component.yaml
+echo "> Updating Flux controller images in .ocm/base-component.yaml"
+
+BASE_COMPONENT=$REPO_ROOT/.ocm/base-component.yaml
+
+update_ocm_resource() {
+  local name=$1
+  local image=$2
+  local tag="${image##*:}"
+  yq -i "(.resources[] | select(.name == \"${name}\") | .version) = \"${tag}\"" "$BASE_COMPONENT"
+  yq -i "(.resources[] | select(.name == \"${name}\") | .access.imageReference) = \"${image}\"" "$BASE_COMPONENT"
+}
+
+update_ocm_resource "source-controller" "$SOURCE_IMAGE"
+update_ocm_resource "kustomize-controller" "$KUSTOMIZE_IMAGE"
+update_ocm_resource "helm-controller" "$HELM_IMAGE"
+update_ocm_resource "notification-controller" "$NOTIFICATION_IMAGE"
+
 ## Replace actual images in gotk-components.yaml with template placeholders
 echo "> Replacing images in gotk-components.yaml with template placeholders"
 

--- a/hack/flux-gotk-generate.sh
+++ b/hack/flux-gotk-generate.sh
@@ -41,59 +41,43 @@ sed -i 's|branch\:\s<branch>|{{ .repo_ref }}|g' $REPO_ROOT/pkg/components/flux/t
 sed -i -e 's/recurseSubmodules: true/recurseSubmodules: true # required if Git submodules are used, e.g. to include the base repo in the landscape repo./g' \
   $REPO_ROOT/pkg/components/flux/templates/landscape/flux-system/gotk-sync.yaml
 
-## Extract controller images from gotk-components.yaml and update componentvector/components.yaml
-echo "> Updating Flux controller images in componentvector/components.yaml"
-
 GOTK=$REPO_ROOT/pkg/components/flux/templates/landscape/flux-system/gotk-components.yaml
 COMPONENTS=$REPO_ROOT/componentvector/components.yaml
+OCM_BASE_COMPONENT=$REPO_ROOT/.ocm/base-component.yaml
 
-extract_image() {
-  grep -oP "(?<=image: )ghcr\.io/fluxcd/${1}:[^\s]+" "$GOTK" | head -1
+# Convert a hyphenated controller name to camelCase key, e.g. "source-controller" -> "sourceController"
+to_camel_case() {
+  echo "$1" | sed -E 's/-([a-z])/\U\1/g'
 }
-
-SOURCE_IMAGE=$(extract_image "source-controller")
-KUSTOMIZE_IMAGE=$(extract_image "kustomize-controller")
-HELM_IMAGE=$(extract_image "helm-controller")
-NOTIFICATION_IMAGE=$(extract_image "notification-controller")
 
 GLK_INDEX=$(yq '.components | to_entries | .[] | select(.value.name == "github.com/gardener/gardener-landscape-kit") | .key' "$COMPONENTS")
 
-update_resource() {
-  local resource_key=$1
-  local image=$2
-  local repo="${image%:*}"
-  local tag="${image##*:}"
-  yq -i ".components[${GLK_INDEX}].resources.${resource_key}.ociImage.repository = \"${repo}\"" "$COMPONENTS"
-  yq -i ".components[${GLK_INDEX}].resources.${resource_key}.ociImage.tag = \"${tag}\"" "$COMPONENTS"
-}
+## Extract all Flux controller images from gotk-components.yaml and update downstream files
+echo "> Updating Flux controller images in componentvector/components.yaml and .ocm/base-component.yaml"
 
-update_resource "sourceController" "$SOURCE_IMAGE"
-update_resource "kustomizeController" "$KUSTOMIZE_IMAGE"
-update_resource "helmController" "$HELM_IMAGE"
-update_resource "notificationController" "$NOTIFICATION_IMAGE"
+# Clear existing Flux controller resources so stale entries don't accumulate.
+GLK_INDEX=$GLK_INDEX yq -i '.components[env(GLK_INDEX)].resources = {}' "$COMPONENTS"
+ocm_resources_file=$(mktemp)
+echo "[]" > "$ocm_resources_file"
 
-## Update Flux controller images in .ocm/base-component.yaml
-echo "> Updating Flux controller images in .ocm/base-component.yaml"
+while IFS= read -r image; do
+  # image is e.g. "ghcr.io/fluxcd/source-controller:v1.8.5"
+  controller="${image#ghcr.io/fluxcd/}"   # "source-controller:v1.8.5"
+  controller="${controller%%:*}"           # "source-controller"
+  tag="${image##*:}"                       # "v1.8.5"
+  repo="${image%:*}"                       # "ghcr.io/fluxcd/source-controller"
+  resource_key=$(to_camel_case "$controller")
 
-BASE_COMPONENT=$REPO_ROOT/.ocm/base-component.yaml
+  GLK_INDEX=$GLK_INDEX resource_key=$resource_key repo=$repo tag=$tag \
+    yq -i '.components[env(GLK_INDEX)].resources[env(resource_key)].ociImage.repository = env(repo) |
+           .components[env(GLK_INDEX)].resources[env(resource_key)].ociImage.tag = env(tag)' "$COMPONENTS"
 
-update_ocm_resource() {
-  local name=$1
-  local image=$2
-  local tag="${image##*:}"
-  yq -i "(.resources[] | select(.name == \"${name}\") | .version) = \"${tag}\"" "$BASE_COMPONENT"
-  yq -i "(.resources[] | select(.name == \"${name}\") | .access.imageReference) = \"${image}\"" "$BASE_COMPONENT"
-}
+  controller=$controller tag=$tag image=$image \
+    yq -i '. += [{"name": env(controller), "version": env(tag), "type": "ociImage", "relation": "external", "access": {"type": "ociRegistry", "imageReference": env(image)}}]' \
+    "$ocm_resources_file"
 
-update_ocm_resource "source-controller" "$SOURCE_IMAGE"
-update_ocm_resource "kustomize-controller" "$KUSTOMIZE_IMAGE"
-update_ocm_resource "helm-controller" "$HELM_IMAGE"
-update_ocm_resource "notification-controller" "$NOTIFICATION_IMAGE"
+  sed -i "s|image: ${image}|image: {{ .resources.${resource_key}.ociImage.ref }}|g" "$GOTK"
+done < <(grep -oP "(?<=image: )ghcr\.io/fluxcd/[^\s]+" "$GOTK" | sort -u)
 
-## Replace actual images in gotk-components.yaml with template placeholders
-echo "> Replacing images in gotk-components.yaml with template placeholders"
-
-sed -i "s|image: ${SOURCE_IMAGE}|image: {{ .resources.sourceController.ociImage.ref }}|g" "$GOTK"
-sed -i "s|image: ${KUSTOMIZE_IMAGE}|image: {{ .resources.kustomizeController.ociImage.ref }}|g" "$GOTK"
-sed -i "s|image: ${HELM_IMAGE}|image: {{ .resources.helmController.ociImage.ref }}|g" "$GOTK"
-sed -i "s|image: ${NOTIFICATION_IMAGE}|image: {{ .resources.notificationController.ociImage.ref }}|g" "$GOTK"
+resources_file=$ocm_resources_file yq -i '.resources = load(env(resources_file))' "$OCM_BASE_COMPONENT"
+rm "$ocm_resources_file"

--- a/hack/flux-gotk-generate.sh
+++ b/hack/flux-gotk-generate.sh
@@ -50,16 +50,24 @@ to_camel_case() {
   echo "$1" | sed -E 's/-([a-z])/\U\1/g'
 }
 
+# Convert a camelCase key to kebab-case, e.g. "fluxCLI" -> "flux-cli", "sourceController" -> "source-controller"
+to_kebab_case() {
+  echo "$1" | sed 's/\([a-z]\)\([A-Z]\)/\1-\2/g; s/\([A-Z]\+\)\([A-Z][a-z]\)/\1-\2/g' | tr '[:upper:]' '[:lower:]'
+}
+
 GLK_INDEX=$(yq '.components | to_entries | .[] | select(.value.name == "github.com/gardener/gardener-landscape-kit") | .key' "$COMPONENTS")
 
 ## Extract all Flux controller images from gotk-components.yaml and update downstream files
 echo "> Updating Flux controller images in componentvector/components.yaml and .ocm/base-component.yaml"
 
-# Clear existing Flux controller resources so stale entries don't accumulate.
-GLK_INDEX=$GLK_INDEX yq -i '.components[env(GLK_INDEX)].resources = {}' "$COMPONENTS"
+# Clear existing Flux controller resources so stale entries don't accumulate, preserving non-controller entries (e.g. fluxCLI).
+GLK_INDEX=$GLK_INDEX yq -i '.components[env(GLK_INDEX)].resources = (.components[env(GLK_INDEX)].resources | with_entries(select(.key == "fluxCLI")))' "$COMPONENTS"
+
 ocm_resources_file=$(mktemp)
+trap "rm -f $ocm_resources_file" EXIT
 echo "[]" > "$ocm_resources_file"
 
+# Add Flux controller images to componentvector/components.yaml.
 while IFS= read -r image; do
   # image is e.g. "ghcr.io/fluxcd/source-controller:v1.8.5"
   controller="${image#ghcr.io/fluxcd/}"   # "source-controller:v1.8.5"
@@ -72,12 +80,16 @@ while IFS= read -r image; do
     yq -i '.components[env(GLK_INDEX)].resources[env(resource_key)].ociImage.repository = env(repo) |
            .components[env(GLK_INDEX)].resources[env(resource_key)].ociImage.tag = env(tag)' "$COMPONENTS"
 
-  controller=$controller tag=$tag image=$image \
-    yq -i '. += [{"name": env(controller), "version": env(tag), "type": "ociImage", "relation": "external", "access": {"type": "ociRegistry", "imageReference": env(image)}}]' \
-    "$ocm_resources_file"
-
   sed -i "s|image: ${image}|image: {{ .resources.${resource_key}.ociImage.ref }}|g" "$GOTK"
 done < <(grep -oP "(?<=image: )ghcr\.io/fluxcd/[^\s]+" "$GOTK" | sort -u)
 
+# Add all gardener-landscape-kit resources from componentvector/components.yaml to .ocm/base-component.yaml.
+while IFS=$'\t' read -r key repo tag; do
+  name=$(to_kebab_case "$key")
+  image="${repo}:${tag}"
+  name=$name tag=$tag image=$image \
+    yq -i '. += [{"name": env(name), "version": env(tag), "type": "ociImage", "relation": "external", "access": {"type": "ociRegistry", "imageReference": env(image)}}]' \
+    "$ocm_resources_file"
+done < <(GLK_INDEX=$GLK_INDEX yq '.components[env(GLK_INDEX)].resources | to_entries | .[] | .key + "\t" + .value.ociImage.repository + "\t" + .value.ociImage.tag' "$COMPONENTS")
+
 resources_file=$ocm_resources_file yq -i '.resources = load(env(resources_file))' "$OCM_BASE_COMPONENT"
-rm "$ocm_resources_file"

--- a/hack/flux-gotk-generate.sh
+++ b/hack/flux-gotk-generate.sh
@@ -40,3 +40,42 @@ sed -i 's|branch\:\s<branch>|{{ .repo_ref }}|g' $REPO_ROOT/pkg/components/flux/t
 ## Add comment for recurseSubmodules
 sed -i -e 's/recurseSubmodules: true/recurseSubmodules: true # required if Git submodules are used, e.g. to include the base repo in the landscape repo./g' \
   $REPO_ROOT/pkg/components/flux/templates/landscape/flux-system/gotk-sync.yaml
+
+## Extract controller images from gotk-components.yaml and update componentvector/components.yaml
+echo "> Updating Flux controller images in componentvector/components.yaml"
+
+GOTK=$REPO_ROOT/pkg/components/flux/templates/landscape/flux-system/gotk-components.yaml
+COMPONENTS=$REPO_ROOT/componentvector/components.yaml
+
+extract_image() {
+  grep -oP "(?<=image: )ghcr\.io/fluxcd/${1}:[^\s]+" "$GOTK" | head -1
+}
+
+SOURCE_IMAGE=$(extract_image "source-controller")
+KUSTOMIZE_IMAGE=$(extract_image "kustomize-controller")
+HELM_IMAGE=$(extract_image "helm-controller")
+NOTIFICATION_IMAGE=$(extract_image "notification-controller")
+
+GLK_INDEX=$(yq '.components | to_entries | .[] | select(.value.name == "github.com/gardener/gardener-landscape-kit") | .key' "$COMPONENTS")
+
+update_resource() {
+  local resource_key=$1
+  local image=$2
+  local repo="${image%:*}"
+  local tag="${image##*:}"
+  yq -i ".components[${GLK_INDEX}].resources.${resource_key}.ociImage.repository = \"${repo}\"" "$COMPONENTS"
+  yq -i ".components[${GLK_INDEX}].resources.${resource_key}.ociImage.tag = \"${tag}\"" "$COMPONENTS"
+}
+
+update_resource "sourceController" "$SOURCE_IMAGE"
+update_resource "kustomizeController" "$KUSTOMIZE_IMAGE"
+update_resource "helmController" "$HELM_IMAGE"
+update_resource "notificationController" "$NOTIFICATION_IMAGE"
+
+## Replace actual images in gotk-components.yaml with template placeholders
+echo "> Replacing images in gotk-components.yaml with template placeholders"
+
+sed -i "s|image: ${SOURCE_IMAGE}|image: {{ .resources.sourceController.ociImage.ref }}|g" "$GOTK"
+sed -i "s|image: ${KUSTOMIZE_IMAGE}|image: {{ .resources.kustomizeController.ociImage.ref }}|g" "$GOTK"
+sed -i "s|image: ${HELM_IMAGE}|image: {{ .resources.helmController.ociImage.ref }}|g" "$GOTK"
+sed -i "s|image: ${NOTIFICATION_IMAGE}|image: {{ .resources.notificationController.ociImage.ref }}|g" "$GOTK"

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -4,17 +4,16 @@
 
 GLK_PRETTIFY        := $(TOOLS_BIN_DIR)/prettify
 
-# renovate: datasource=github-releases depName=fluxcd/flux2
-FLUX_CLI_VERSION ?= v2.8.8
+FLUX_CLI_VERSION ?= $(shell grep -A3 'fluxCLI:' $(REPO_ROOT)/componentvector/components.yaml | sed -n 's/.*tag: //p')
 GLK_PRETTIFY_VERSION = $(shell git rev-parse HEAD)
 
 FLUX_CLI ?= $(TOOLS_DIR)/bin/$(SYSTEM_NAME)-$(SYSTEM_ARCH)/flux
 .PHONY: flux-cli
 flux-cli: $(FLUX_CLI)
 $(FLUX_CLI): $(TOOLS_DIR) $(call tool_version_file,$(FLUX_CLI),$(FLUX_CLI_VERSION))
-	curl -Lo $(FLUX_CLI).tar.gz https://github.com/fluxcd/flux2/releases/download/$(FLUX_CLI_VERSION)/flux_$(FLUX_CLI_VERSION:v%=%)_$(SYSTEM_NAME)_$(SYSTEM_ARCH).tar.gz
-	tar -zxvf $(FLUX_CLI).tar.gz -C $(TOOLS_DIR)/bin/$(SYSTEM_NAME)-$(SYSTEM_ARCH) flux
-	touch $(FLUX_CLI) && chmod +x $(FLUX_CLI) && rm $(FLUX_CLI).tar.gz
+	@mkdir -p $(dir $(FLUX_CLI))
+	@printf '#!/usr/bin/env bash\nset -e\ndocker run --rm -v "$(REPO_ROOT):$(REPO_ROOT)" ghcr.io/fluxcd/flux-cli:$(FLUX_CLI_VERSION) "$$@"\n' > $(FLUX_CLI)
+	@chmod +x $(FLUX_CLI)
 
 $(GLK_PRETTIFY): $(call tool_version_file,$(GLK_PRETTIFY),$(GLK_PRETTIFY_VERSION))
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install ./hack/tools/prettify

--- a/pkg/components/flux/component.go
+++ b/pkg/components/flux/component.go
@@ -9,6 +9,9 @@ import (
 	"path"
 	"strings"
 
+	"github.com/gardener/gardener/pkg/utils"
+
+	"github.com/gardener/gardener-landscape-kit/componentvector"
 	"github.com/gardener/gardener-landscape-kit/pkg/components"
 	"github.com/gardener/gardener-landscape-kit/pkg/utils/files"
 )
@@ -81,12 +84,19 @@ func writeLandscapeTemplateFiles(opts components.LandscapeOptions) error {
 	fluxPath := path.Join(opts.GetRelativeLandscapePath(), DirName)
 	fluxPath = strings.TrimPrefix(fluxPath, "./")
 
-	objects, err := files.RenderTemplateFiles(landscapeTemplates, landscapeTemplateDir, map[string]any{
+	cvValues, err := components.GetComponentVectorTemplateValues(opts, componentvector.NameGardenerGardenerLandscapeKit)
+	if err != nil {
+		return err
+	}
+
+	values := utils.MergeMaps(cvValues, map[string]any{
 		"repo_url":        opts.GetLandscapeURL(),
 		"repo_ref":        repoRef,
 		"flux_path":       fluxPath,
 		"components_path": path.Join(opts.GetRelativeLandscapePath(), components.DirName),
 	})
+
+	objects, err := files.RenderTemplateFiles(landscapeTemplates, landscapeTemplateDir, values)
 	if err != nil {
 		return err
 	}

--- a/pkg/components/flux/component_test.go
+++ b/pkg/components/flux/component_test.go
@@ -251,10 +251,10 @@ var _ = Describe("Flux Component Generation", func() {
 				Expect(err).NotTo(HaveOccurred())
 				content := string(data)
 
-				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/source-controller:v1.8.5"))
-				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/kustomize-controller:v1.8.5"))
-				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/helm-controller:v1.5.5"))
-				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/notification-controller:v1.8.4"))
+				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/source-controller:v"))
+				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/kustomize-controller:v"))
+				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/helm-controller:v"))
+				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/notification-controller:v"))
 			})
 
 			It("should use overridden images from the component vector resources", func() {

--- a/pkg/components/flux/component_test.go
+++ b/pkg/components/flux/component_test.go
@@ -19,12 +19,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
+	"github.com/gardener/gardener-landscape-kit/componentvector"
 	"github.com/gardener/gardener-landscape-kit/pkg/apis/config/v1alpha1"
 	"github.com/gardener/gardener-landscape-kit/pkg/cmd"
 	generateoptions "github.com/gardener/gardener-landscape-kit/pkg/cmd/generate/options"
 	"github.com/gardener/gardener-landscape-kit/pkg/components"
 	. "github.com/gardener/gardener-landscape-kit/pkg/components/flux"
+	utilscomponentvector "github.com/gardener/gardener-landscape-kit/pkg/utils/componentvector"
+	"github.com/gardener/gardener-landscape-kit/pkg/utils/test"
 )
 
 var (
@@ -219,6 +223,70 @@ var _ = Describe("Flux Component Generation", func() {
 				test(opts, MatchFields(IgnoreExtras, Fields{
 					"Commit": Equal("a1b2c3d4"),
 				}))
+			})
+		})
+
+		Context("GOTK Components Manifest", func() {
+			writeComponentsVectorFile := func(resourcesYAML string) {
+				resources, err := test.UnmarshalToResources(resourcesYAML)
+				Expect(err).NotTo(HaveOccurred())
+				cv := &utilscomponentvector.ComponentVector{
+					Name:      componentvector.NameGardenerGardenerLandscapeKit,
+					Version:   "v0.3.0-dev",
+					Resources: resources,
+				}
+				cvs := &utilscomponentvector.Components{Components: []*utilscomponentvector.ComponentVector{cv}}
+				content, err := yaml.Marshal(cvs)
+				Expect(err).NotTo(HaveOccurred())
+				// The flux test uses targetPath="/" → repoRoot="/", baseLink="", base.Target="./"
+				// so the component vector override file is read from "/components.yaml".
+				Expect(fs.WriteFile("/components.yaml", content, 0o644)).To(Succeed())
+			}
+
+			It("should use default images when no component vector resources are set", func() {
+				component := NewComponent()
+				Expect(component.GenerateLandscape(opts)).To(Succeed())
+
+				data, err := fs.ReadFile("/landscapeDir/flux/flux-system/gotk-components.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				content := string(data)
+
+				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/source-controller:v1.8.5"))
+				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/kustomize-controller:v1.8.5"))
+				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/helm-controller:v1.5.5"))
+				Expect(content).To(ContainSubstring("image: ghcr.io/fluxcd/notification-controller:v1.8.4"))
+			})
+
+			It("should use overridden images from the component vector resources", func() {
+				writeComponentsVectorFile(`
+sourceController:
+  ociImage:
+    ref: my.registry.io/fluxcd/source-controller:v9.9.9
+kustomizeController:
+  ociImage:
+    ref: my.registry.io/fluxcd/kustomize-controller:v9.9.9
+helmController:
+  ociImage:
+    ref: my.registry.io/fluxcd/helm-controller:v9.9.9
+notificationController:
+  ociImage:
+    ref: my.registry.io/fluxcd/notification-controller:v9.9.9
+`)
+				opts = buildOpts()
+
+				component := NewComponent()
+				Expect(component.GenerateLandscape(opts)).To(Succeed())
+
+				data, err := fs.ReadFile("/landscapeDir/flux/flux-system/gotk-components.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				content := string(data)
+
+				Expect(content).To(ContainSubstring("image: my.registry.io/fluxcd/source-controller:v9.9.9"))
+				Expect(content).To(ContainSubstring("image: my.registry.io/fluxcd/kustomize-controller:v9.9.9"))
+				Expect(content).To(ContainSubstring("image: my.registry.io/fluxcd/helm-controller:v9.9.9"))
+				Expect(content).To(ContainSubstring("image: my.registry.io/fluxcd/notification-controller:v9.9.9"))
+
+				Expect(content).NotTo(ContainSubstring("ghcr.io/fluxcd"))
 			})
 		})
 	})

--- a/pkg/components/flux/templates/landscape/flux-system/gotk-components.yaml
+++ b/pkg/components/flux/templates/landscape/flux-system/gotk-components.yaml
@@ -2560,7 +2560,7 @@ spec:
             resourceFieldRef:
               containerName: manager
               resource: limits.memory
-        image: ghcr.io/fluxcd/source-controller:v1.8.5
+        image: {{ .resources.sourceController.ociImage.ref }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -3387,7 +3387,7 @@ spec:
             resourceFieldRef:
               containerName: manager
               resource: limits.memory
-        image: ghcr.io/fluxcd/kustomize-controller:v1.8.5
+        image: {{ .resources.kustomizeController.ociImage.ref }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -4943,7 +4943,7 @@ spec:
             resourceFieldRef:
               containerName: manager
               resource: limits.memory
-        image: ghcr.io/fluxcd/helm-controller:v1.5.5
+        image: {{ .resources.helmController.ociImage.ref }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -6383,7 +6383,7 @@ spec:
             resourceFieldRef:
               containerName: manager
               resource: limits.memory
-        image: ghcr.io/fluxcd/notification-controller:v1.8.4
+        image: {{ .resources.notificationController.ociImage.ref }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source delivery
/kind enhancement

**What this PR does / why we need it**:
Add Flux images as GLK resources to allow for optional image overwrites, .e.g., when public images are not accessible from an isolated environment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Flux images were added to the `gardener-landscape-kit`. They can now be overwritten via the `components.yaml` file for sovereign environments.
```
