### PR TITLE
Fix image overwrite for seed's dns-controller-manager of the shoot-dns-service extension

### DIFF
--- a/pkg/components/gardener-extensions/shoot-dns-service/component.go
+++ b/pkg/components/gardener-extensions/shoot-dns-service/component.go
@@ -6,12 +6,16 @@ package dnsservice
 
 import (
 	"embed"
+	"fmt"
 	"path"
 
 	"github.com/gardener/gardener/pkg/utils"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gardener/gardener-landscape-kit/componentvector"
 	"github.com/gardener/gardener-landscape-kit/pkg/components"
+	"github.com/gardener/gardener-landscape-kit/pkg/ocm/components/helpers"
+	utilscomponentvector "github.com/gardener/gardener-landscape-kit/pkg/utils/componentvector"
 	"github.com/gardener/gardener-landscape-kit/pkg/utils/files"
 )
 
@@ -88,9 +92,14 @@ func writeLandscapeTemplateFiles(opts components.LandscapeOptions) error {
 	if err != nil {
 		return err
 	}
+	dnsControllerManagerImageValue, err := addDNSControllerManagerImageValue(renderValue)
+	if err != nil {
+		return err
+	}
 	values := utils.MergeMaps(renderValue, map[string]any{
-		"relativePathToBaseComponent": opts.GetRelativeBaseComponentPath(ComponentDirectory),
+		"dnsControllerManagerImage":   dnsControllerManagerImageValue,
 		"landscapeComponentPath":      path.Join(opts.GetRelativeLandscapePath(), relativeComponentPath),
+		"relativePathToBaseComponent": opts.GetRelativeBaseComponentPath(ComponentDirectory),
 	})
 	objects, err := files.RenderTemplateFiles(landscapeTemplates, landscapeTemplateDir, values)
 	if err != nil {
@@ -98,4 +107,32 @@ func writeLandscapeTemplateFiles(opts components.LandscapeOptions) error {
 	}
 
 	return files.WriteObjectsToFilesystem(objects, opts.GetTargetPath(), path.Join(components.DirName, ComponentDirectory), opts.GetFilesystem(), opts.GetMergeMode())
+}
+
+func addDNSControllerManagerImageValue(renderValue map[string]any) (map[string]any, error) {
+	imageVectorOverwrite, ok := renderValue["imageVectorOverwrite"]
+	if !ok {
+		return nil, nil
+	}
+	data, ok := imageVectorOverwrite.(string)
+	if !ok {
+		return nil, fmt.Errorf("imageVectorOverwrite is not a string")
+	}
+	var obj utilscomponentvector.ImageVectorOverwrite
+	if err := yaml.Unmarshal([]byte(data), &obj); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal imageVectorOverwrite: %w", err)
+	}
+	for _, img := range obj.Images {
+		if img.Name == "dns-controller-manager" {
+			repository, tag, err := helpers.RepoTagFromRefOrParts(img.Repository, img.Tag, img.Ref)
+			if err != nil {
+				return nil, fmt.Errorf("invalid image %q: %w", img.Name, err)
+			}
+			return map[string]any{
+				"repository": repository,
+				"tag":        tag,
+			}, nil
+		}
+	}
+	return nil, nil
 }

--- a/pkg/components/gardener-extensions/shoot-dns-service/component_test.go
+++ b/pkg/components/gardener-extensions/shoot-dns-service/component_test.go
@@ -116,8 +116,8 @@ var _ = Describe("Component Generation", func() {
 					WithImageVectorOverwrite(componentvector.ImageVectorOverwrite{
 						Images: []imagevector.ImageSource{
 							{
-								Name: "component1",
-								Ref:  new("test.repo/path/component1:v1.2.3"),
+								Name: "dns-controller-manager",
+								Ref:  new("test.repo/path/dns-controller-manager:v4.5.6"),
 							},
 						},
 					}).

--- a/pkg/components/gardener-extensions/shoot-dns-service/templates/landscape/extension.yaml
+++ b/pkg/components/gardener-extensions/shoot-dns-service/templates/landscape/extension.yaml
@@ -22,19 +22,15 @@ spec:
         ociRepository:
           ref: {{ .resources.shootDnsService.helmChart.ref }}
       {{- if (or .resources.shootDnsService.helmChart.imageMap .imageVectorOverwrite) }}
-      runtimeClusterValues:
-        {{- if .resources.shootDnsService.helmChart.imageMap }}
-{{ toIndentYAML 2 .resources.shootDnsService.helmChart.imageMap.gardenerExtensionShootDnsService | indent 8 }}
-        {{- end }}
-        {{- if .imageVectorOverwrite }}
-        imageVectorOverwrite: |
-{{ indent 10 .imageVectorOverwrite }}
-        {{- end }}
-      {{- end }}
-      {{- if (or .resources.shootDnsService.helmChart.imageMap .imageVectorOverwrite) }}
       values:
         {{- if .resources.shootDnsService.helmChart.imageMap }}
 {{ toIndentYAML 2 .resources.shootDnsService.helmChart.imageMap.gardenerExtensionShootDnsService | indent 8 }}
+        {{- end }}
+        {{- if .dnsControllerManagerImage }}
+        dnsControllerManager:
+          image:
+            repository: {{ .dnsControllerManagerImage.repository }}
+            tag: {{ .dnsControllerManagerImage.tag }}
         {{- end }}
         {{- if .imageVectorOverwrite }}
         imageVectorOverwrite: |

--- a/pkg/components/gardener-extensions/shoot-dns-service/testdata/expected-kustomize-ocm.yaml
+++ b/pkg/components/gardener-extensions/shoot-dns-service/testdata/expected-kustomize-ocm.yaml
@@ -23,22 +23,18 @@ spec:
       helm:
         ociRepository:
           ref: test-repo/path/charts/gardener/extensions/shoot-dns-service:v1.2.3
-      runtimeClusterValues:
-        image:
-          repository: test-repo/path/gardener/extensions/shoot-dns-service
-          tag: v1.2.3
-        imageVectorOverwrite: |
-          images:
-          - name: component1
-            ref: test.repo/path/component1:v1.2.3
       values:
+        dnsControllerManager:
+          image:
+            repository: test.repo/path/dns-controller-manager
+            tag: v4.5.6
         image:
           repository: test-repo/path/gardener/extensions/shoot-dns-service
           tag: v1.2.3
         imageVectorOverwrite: |
           images:
-          - name: component1
-            ref: test.repo/path/component1:v1.2.3
+          - name: dns-controller-manager
+            ref: test.repo/path/dns-controller-manager:v4.5.6
   resources:
   - autoEnable:
     - shoot

--- a/pkg/components/gardener/operator/component.go
+++ b/pkg/components/gardener/operator/component.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	"github.com/gardener/gardener/pkg/utils"
-	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener-landscape-kit/componentvector"
 	"github.com/gardener/gardener-landscape-kit/pkg/components"
@@ -142,12 +141,9 @@ func getHelmChartRepoTagFromComponentVector(name string, cv *utilscomponentvecto
 	if data.HelmChart == nil {
 		return "", "", fmt.Errorf("HelmChart not found for component %s", name)
 	}
-	if data.HelmChart.Repository != nil && data.HelmChart.Tag != nil {
-		return *data.HelmChart.Repository, *data.HelmChart.Tag, nil
+	repository, tag, err := helpers.RepoTagFromRefOrParts(data.HelmChart.Repository, data.HelmChart.Tag, data.HelmChart.Ref)
+	if err != nil {
+		return "", "", fmt.Errorf("HelmChart reference not found for component %s: %w", name, err)
 	}
-	ref := data.HelmChart.Ref
-	if ptr.Deref(ref, "") == "" {
-		return "", "", fmt.Errorf("HelmChart reference not found for component %s", name)
-	}
-	return helpers.SplitOCIImageReference(*ref)
+	return repository, tag, nil
 }

--- a/pkg/ocm/components/helpers/helm.go
+++ b/pkg/ocm/components/helpers/helm.go
@@ -54,3 +54,16 @@ func SplitOCIImageReference(ref string) (string, string, error) {
 	}
 	return ref[:lastIndex+idx], ref[lastIndex+idx+1:], nil
 }
+
+// RepoTagFromRefOrParts resolves repository and tag from either explicit
+// repository+tag fields or by splitting a ref string. It mirrors the field
+// layout of imagevector.ImageSource and componentvector.HelmChart / OCIImage.
+func RepoTagFromRefOrParts(repository, tag, ref *string) (string, string, error) {
+	if repository != nil && tag != nil {
+		return *repository, *tag, nil
+	}
+	if ref != nil {
+		return SplitOCIImageReference(*ref)
+	}
+	return "", "", fmt.Errorf("neither repository+tag nor ref is set")
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes the shoot-dns-service extension component to correctly overwrite the dns-controller-manager image for the deployment in the extension namespace.

The section`runtimeClusterValues` has been dropped as they are not used for the shoot-dns-service extension.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix image overwrite for seed's dns-controller-manager of the shoot-dns-service extension.
```
