### PR TITLE
Add `customRepositoryBase` field to `OCMConfig` for `relativeOciReference` resolution

### DIFF
--- a/docs/api-reference/landscapekit-v1alpha1.md
+++ b/docs/api-reference/landscapekit-v1alpha1.md
@@ -149,6 +149,7 @@ _Appears in:_
 | `rootComponent` _[OCMComponent](#ocmcomponent)_ | RootComponent is the configuration of the root component. |  |  |
 | `originalRefs` _boolean_ | OriginalRefs is a flag to output original image references in the image vectors. |  |  |
 | `ignoreMissingComponents` _boolean_ | IgnoreMissingComponents indicates whether to ignore missing components during resolution. |  | Optional: \{\} <br /> |
+| `customRepositoryBase` _string_ | CustomRepositoryBase allows to override the OCI repository base for `relativeOciReferences`.<br />The value must be a bare host (optionally with port and/or path) without a scheme prefix,<br />e.g. "registry.example.com", "registry.example.com:5000", or "registry.example.com/myproject".<br />If not specified, it defaults to the repository host the component descriptor was read from. |  | Optional: \{\} <br /> |
 
 
 #### RepositoriesConfig

--- a/docs/usage/ocm/relative-oci-reference.md
+++ b/docs/usage/ocm/relative-oci-reference.md
@@ -31,10 +31,15 @@ The `reference` field must contain a path with a tag (`name:tag`), a digest (`na
 When GLK looks up a component version it remembers the host of the repository the descriptor was found in. While extracting resources from the descriptor, every `relativeOciReference` access is resolved into a fully-qualified image reference using the rule:
 
 ```
-<repository-host> + "/" + <reference>
+<repository-base> + "/" + <reference>
 ```
 
-The repository host is the hostname (with optional port) parsed from the repository URL — the scheme and any path are dropped.
+By default, the repository base is the hostname (with optional port) parsed from the repository URL — the scheme and any path are dropped. This can be overridden by setting `ocm.customRepositoryBase` in the GLK configuration, which replaces the auto-detected host for all `relativeOciReference` resolutions. This is useful when the component descriptor was mirrored to a registry whose URL differs from the original producer's host.
+
+The value must be a bare host without a scheme prefix, and may optionally include a port and/or a path prefix, for example:
+- `registry.example.com`
+- `registry.example.com:5000`
+- `registry.example.com/myproject`
 
 A leading `/` on the relative reference is also stripped to avoid producing a double slash. As a concrete example, given:
 

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -105,6 +105,12 @@ type OCMConfig struct {
 	// IgnoreMissingComponents indicates whether to ignore missing components during resolution.
 	// +optional
 	IgnoreMissingComponents *bool `json:"ignoreMissingComponents,omitempty"`
+	// CustomRepositoryBase allows to override the OCI repository base for `relativeOciReferences`.
+	// The value must be a bare host (optionally with port and/or path) without a scheme prefix,
+	// e.g. "registry.example.com", "registry.example.com:5000", or "registry.example.com/myproject".
+	// If not specified, it defaults to the repository host the component descriptor was read from.
+	// +optional
+	CustomRepositoryBase *string `json:"customRepositoryBase,omitempty"`
 }
 
 // OCMComponent specifies a OCM component.

--- a/pkg/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/apis/config/v1alpha1/validation/validation.go
@@ -144,6 +144,29 @@ func ValidateOCMConfig(conf *configv1alpha1.OCMConfig, fldPath *field.Path) fiel
 		}
 	}
 
+	if conf.CustomRepositoryBase != nil {
+		base := *conf.CustomRepositoryBase
+		basePath := fldPath.Child("customRepositoryBase")
+		switch {
+		case strings.TrimSpace(base) == "":
+			allErrs = append(allErrs, field.Invalid(basePath, base, "must not be empty"))
+		case strings.Contains(base, "://"):
+			allErrs = append(allErrs, field.Invalid(basePath, base, "must not contain a scheme prefix (e.g. 'registry.example.com', not 'https://registry.example.com')"))
+		default:
+			u, err := url.Parse("https://" + base)
+			switch {
+			case err != nil:
+				allErrs = append(allErrs, field.Invalid(basePath, base, "invalid url: "+err.Error()))
+			case u.Host == "":
+				allErrs = append(allErrs, field.Invalid(basePath, base, "must specify a host (e.g. 'registry.example.com')"))
+			case u.User != nil:
+				allErrs = append(allErrs, field.Invalid(basePath, base, "must not contain user info"))
+			case u.RawQuery != "" || u.Fragment != "":
+				allErrs = append(allErrs, field.Invalid(basePath, base, "must not contain a query or fragment"))
+			}
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/config/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/config/v1alpha1/validation/validation_test.go
@@ -515,4 +515,39 @@ func setupOCMConfigTests(test func(conf *v1alpha1.OCMConfig) field.ErrorList, ba
 			})),
 		))
 	})
+
+	DescribeTable("customRepositoryBase",
+		func(base string, valid bool) {
+			conf := &v1alpha1.OCMConfig{
+				Repositories: []string{"https://example.com/repo"},
+				RootComponent: v1alpha1.OCMComponent{
+					Name:    "example.com/org/component",
+					Version: "1.0.0",
+				},
+				CustomRepositoryBase: &base,
+			}
+
+			errList := test(conf)
+			if valid {
+				Expect(errList).To(BeEmpty())
+				return
+			}
+			Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal(baseFldPath.Child("customRepositoryBase").String()),
+				"BadValue": Equal(base),
+			}))))
+		},
+		Entry("valid host", "registry.example.com", true),
+		Entry("valid host with port and path", "registry.example.com:1234/sub/path", true),
+		Entry("scheme prefix", "https://registry.example.com", false),
+		Entry("empty string", "", false),
+		Entry("whitespace only", "   ", false),
+		Entry("invalid url with control character", "host\x00name", false),
+		Entry("invalid port", "registry.example.com:notaport", false),
+		Entry("missing host", "/only/path", false),
+		Entry("contains user info", "user@registry.example.com", false),
+		Entry("contains query", "registry.example.com/path?q=1", false),
+		Entry("contains fragment", "registry.example.com#frag", false),
+	)
 }

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -183,6 +183,11 @@ func (in *OCMConfig) DeepCopyInto(out *OCMConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CustomRepositoryBase != nil {
+		in, out := &in.CustomRepositoryBase, &out.CustomRepositoryBase
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cmd/resolve/ocm/ocm.go
+++ b/pkg/cmd/resolve/ocm/ocm.go
@@ -18,6 +18,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	configv1alpha1 "github.com/gardener/gardener-landscape-kit/pkg/apis/config/v1alpha1"
+	configv1alpha1validation "github.com/gardener/gardener-landscape-kit/pkg/apis/config/v1alpha1/validation"
 	"github.com/gardener/gardener-landscape-kit/pkg/cmd"
 	"github.com/gardener/gardener-landscape-kit/pkg/ocm"
 	"github.com/gardener/gardener-landscape-kit/pkg/utils/files"
@@ -100,6 +101,10 @@ func (o *Options) complete() error {
 func (o *Options) validate() error {
 	if o.Config == nil || o.Config.OCM == nil {
 		return fmt.Errorf("OCM configuration is required")
+	}
+
+	if errs := configv1alpha1validation.ValidateLandscapeKitConfiguration(o.Config); len(errs) > 0 {
+		return fmt.Errorf("invalid configuration: %v", errs.ToAggregate())
 	}
 
 	return nil

--- a/pkg/ocm/components/components.go
+++ b/pkg/ocm/components/components.go
@@ -20,6 +20,7 @@ import (
 	accessv1 "ocm.software/open-component-model/bindings/go/oci/spec/access/v1"
 
 	"github.com/gardener/gardener-landscape-kit/componentvector"
+	configv1alpha1 "github.com/gardener/gardener-landscape-kit/pkg/apis/config/v1alpha1"
 	"github.com/gardener/gardener-landscape-kit/pkg/ocm/components/helpers"
 	ocmimagevector "github.com/gardener/gardener-landscape-kit/pkg/ocm/imagevector"
 	"github.com/gardener/gardener-landscape-kit/pkg/ocm/ociaccess"
@@ -55,11 +56,12 @@ type Dependency struct {
 
 // Components manages a collection of components, their dependencies, and associated image vectors.
 type Components struct {
-	lock         sync.Mutex
-	dependents   map[ComponentReference]sets.Set[ComponentReference]
-	dependencies map[ComponentReference][]Dependency
-	mappedImages map[ComponentReference][]*ocmimagevector.ExtendedImageSource
-	resources    map[ComponentReference][]Resource
+	lock                 sync.Mutex
+	dependents           map[ComponentReference]sets.Set[ComponentReference]
+	dependencies         map[ComponentReference][]Dependency
+	mappedImages         map[ComponentReference][]*ocmimagevector.ExtendedImageSource
+	resources            map[ComponentReference][]Resource
+	customRepositoryBase *string
 
 	kubernetesComponent *ComponentReference
 }
@@ -88,12 +90,17 @@ type ResourcesOutput struct {
 }
 
 // NewComponents creates a new instance of Components.
-func NewComponents() *Components {
+func NewComponents(cfg *configv1alpha1.OCMConfig) *Components {
+	var customRepositoryBase *string
+	if cfg != nil {
+		customRepositoryBase = cfg.CustomRepositoryBase
+	}
 	return &Components{
-		dependents:   make(map[ComponentReference]sets.Set[ComponentReference]),
-		dependencies: make(map[ComponentReference][]Dependency),
-		mappedImages: make(map[ComponentReference][]*ocmimagevector.ExtendedImageSource),
-		resources:    make(map[ComponentReference][]Resource),
+		dependents:           make(map[ComponentReference]sets.Set[ComponentReference]),
+		dependencies:         make(map[ComponentReference][]Dependency),
+		mappedImages:         make(map[ComponentReference][]*ocmimagevector.ExtendedImageSource),
+		resources:            make(map[ComponentReference][]Resource),
+		customRepositoryBase: customRepositoryBase,
 	}
 }
 
@@ -155,7 +162,7 @@ func (c *Components) addComponent(result *ociaccess.FindComponentVersionResult) 
 func (c *Components) extractImageVectorFromResources(result *ociaccess.FindComponentVersionResult) ([]ocmimagevector.ExtendedImageSource, error) {
 	var vector []ocmimagevector.ExtendedImageSource
 	for _, res := range result.Descriptor.Component.Resources {
-		src, err := resourceToImageSource(res, result.RepositoryHost)
+		src, err := c.resourceToImageSource(res, result.RepositoryHost)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert resource %s to image source: %w", res.Name, err)
 		}
@@ -171,7 +178,7 @@ func (c *Components) extractResourcesFromDescriptor(result *ociaccess.FindCompon
 	for _, res := range result.Descriptor.Component.Resources {
 		switch res.Type {
 		case ResourceTypeOCIImage:
-			src, err := resourceToImageSource(res, result.RepositoryHost)
+			src, err := c.resourceToImageSource(res, result.RepositoryHost)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert resource %s to image source: %w", res.Name, err)
 			}
@@ -201,7 +208,7 @@ func (c *Components) extractResourcesFromDescriptor(result *ociaccess.FindCompon
 				resources = append(resources, resource)
 			}
 		case ResourceTypeHelmChart:
-			imageReference, err := extractImageReference(res, result.RepositoryHost)
+			imageReference, err := c.extractImageReference(res, result.RepositoryHost)
 			if err != nil {
 				return nil, err
 			}
@@ -648,6 +655,67 @@ func (c *Components) ComponentsCount() int {
 	return len(c.dependents)
 }
 
+func (c *Components) extractImageReference(res descriptorruntime.Resource, repositoryHost string) (string, error) {
+	repoBase := repositoryHost
+	if v := ptr.Deref(c.customRepositoryBase, ""); v != "" {
+		repoBase = v
+	}
+	return extractImageReference(res, repoBase)
+}
+
+func (c *Components) resourceToImageSource(res descriptorruntime.Resource, repoHost string) (*ocmimagevector.ExtendedImageSource, error) {
+	if res.Type != ResourceTypeOCIImage {
+		return nil, nil
+	}
+
+	var (
+		src ocmimagevector.ExtendedImageSource
+		err error
+	)
+	for _, value := range res.Labels {
+		switch value.Name {
+		case LabelNameImageVectorName:
+			src.Name, err = toString(value.Value)
+			src.ResourceName = res.Name
+		case labelNameImageVectorRepository:
+			src.Repository, err = toStringPtr(value.Value)
+		case labelNameImageVectorSourceRepository:
+			// ignore
+		case labelNameImageVectorTargetVersion:
+			src.TargetVersion, err = toStringPtr(value.Value)
+		case labelNameCveCategorisation:
+			src.Labels = append(src.Labels, value)
+		case LabelNameOriginalRef:
+			src.OriginalRef, err = toStringPtr(value.Value)
+		default:
+			// ignore
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert label %s to string: %w", value.Name, err)
+		}
+	}
+	if src.Name == "" {
+		src.Name = res.Name
+		src.LookupOnly = true
+	}
+	imageReference, err := c.extractImageReference(res, repoHost)
+	if err != nil {
+		return nil, err
+	}
+	src.Ref = &imageReference
+	repo, tag, err := helpers.SplitOCIImageReference(imageReference)
+	if err != nil {
+		return nil, fmt.Errorf("failed to split ref %s: %w", imageReference, err)
+	}
+	src.Repository = &repo
+	src.Tag = &tag
+	if res.Version != "" {
+		src.Version = &res.Version
+	}
+	src.Local = res.Relation == descriptorruntime.LocalRelation
+	return &src, nil
+}
+
 func referenceToComponentReferenceWithImageSource(ref descriptorruntime.Reference) (cref ComponentReference, img *ocmimagevector.ExtendedImageSource, err error) {
 	cref = ComponentReference(fmt.Sprintf("%s:%s", ref.Component, ref.Version))
 	for _, label := range ref.Labels {
@@ -698,65 +766,12 @@ func rawToImageSources(value json.RawMessage) ([]*ocmimagevector.ExtendedImageSo
 	return obj.Images, nil
 }
 
-func resourceToImageSource(res descriptorruntime.Resource, repoHost string) (*ocmimagevector.ExtendedImageSource, error) {
-	if res.Type != ResourceTypeOCIImage {
-		return nil, nil
-	}
-
-	var (
-		src ocmimagevector.ExtendedImageSource
-		err error
-	)
-	for _, value := range res.Labels {
-		switch value.Name {
-		case LabelNameImageVectorName:
-			src.Name, err = toString(value.Value)
-			src.ResourceName = res.Name
-		case labelNameImageVectorRepository:
-			src.Repository, err = toStringPtr(value.Value)
-		case labelNameImageVectorSourceRepository:
-			// ignore
-		case labelNameImageVectorTargetVersion:
-			src.TargetVersion, err = toStringPtr(value.Value)
-		case labelNameCveCategorisation:
-			src.Labels = append(src.Labels, value)
-		case LabelNameOriginalRef:
-			src.OriginalRef, err = toStringPtr(value.Value)
-		default:
-			// ignore
-		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert label %s to string: %w", value.Name, err)
-		}
-	}
-	if src.Name == "" {
-		src.Name = res.Name
-		src.LookupOnly = true
-	}
-	imageReference, err := extractImageReference(res, repoHost)
-	if err != nil {
-		return nil, err
-	}
-	src.Ref = &imageReference
-	repo, tag, err := helpers.SplitOCIImageReference(imageReference)
-	if err != nil {
-		return nil, fmt.Errorf("failed to split ref %s: %w", imageReference, err)
-	}
-	src.Repository = &repo
-	src.Tag = &tag
-	if res.Version != "" {
-		src.Version = &res.Version
-	}
-	src.Local = res.Relation == descriptorruntime.LocalRelation
-	return &src, nil
-}
-
-func extractImageReference(res descriptorruntime.Resource, repoHost string) (string, error) {
+func extractImageReference(res descriptorruntime.Resource, repoBase string) (string, error) {
 	var imageReference string
 	switch a := res.Access.(type) {
 	case *ociaccess.RelativeOciReference:
-		// Relative OCI references carry only a sub-path; prepend the component's repository host to form a fully-qualified image reference.
-		imageReference = strings.TrimRight(repoHost, "/") + "/" + strings.TrimLeft(a.Reference, "/")
+		// Relative OCI references carry only a sub-path; prepend the component's repository base to form a fully-qualified image reference.
+		imageReference = strings.TrimRight(repoBase, "/") + "/" + strings.TrimLeft(a.Reference, "/")
 	case *accessv1.OCIImage:
 		imageReference = a.ImageReference
 	default:
@@ -770,7 +785,7 @@ func extractImageReference(res descriptorruntime.Resource, repoHost string) (str
 		}
 		switch c := converted.(type) {
 		case *ociaccess.RelativeOciReference:
-			imageReference = strings.TrimRight(repoHost, "/") + "/" + strings.TrimLeft(c.Reference, "/")
+			imageReference = strings.TrimRight(repoBase, "/") + "/" + strings.TrimLeft(c.Reference, "/")
 		case *accessv1.OCIImage:
 			imageReference = c.ImageReference
 		default:

--- a/pkg/ocm/components/components_test.go
+++ b/pkg/ocm/components/components_test.go
@@ -19,6 +19,7 @@ import (
 	ocmruntime "ocm.software/open-component-model/bindings/go/runtime"
 	"sigs.k8s.io/yaml"
 
+	configv1alpha1 "github.com/gardener/gardener-landscape-kit/pkg/apis/config/v1alpha1"
 	"github.com/gardener/gardener-landscape-kit/pkg/ocm/ociaccess"
 )
 
@@ -54,7 +55,7 @@ var _ = Describe("Components", func() {
 		}
 	)
 	BeforeEach(func() {
-		c = NewComponents()
+		c = NewComponents(nil)
 	})
 
 	It("should produce correct image vector for extension-shoot-cert-service", func() {
@@ -508,6 +509,27 @@ scheduler:
 		}))
 	})
 
+	It("should resolve relativeOciReference resources against the repository host with custom repository base", func() {
+		customRepoBase := "myrepo.example.com:1234/custom/path"
+		c = NewComponents(&configv1alpha1.OCMConfig{CustomRepositoryBase: new(customRepoBase)})
+		desc := buildRelativeOciDescriptor("example.com/comp-with-relative-ref", "v0.0.2", ResourceTypeOCIImage, "my-image", "v0.0.2", "img/sub-path:v0.0.2@sha256:deadbeef")
+		_, err := c.AddComponentDependencies(&ociaccess.FindComponentVersionResult{
+			Descriptor:     desc,
+			RepositoryHost: "registry.example.com:443",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		ref := ComponentReferenceFromNameAndVersion(desc.Component.Name, desc.Component.Version)
+		imageVector, err := c.GetImageVector(ref, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(imageVector).To(ConsistOf(imagevector.ImageSource{
+			Name:       "my-image",
+			Repository: new(customRepoBase + "/img/sub-path"),
+			Tag:        new("v0.0.2@sha256:deadbeef"),
+			Version:    new("v0.0.2"),
+		}))
+	})
+
 	It("should fail for malformed relativeOciReference resources", func() {
 		desc := buildRelativeOciDescriptor("example.com/comp-with-relative-ref", "v0.0.1", ResourceTypeOCIImage, "my-image", "v0.0.1", "no-tag-no-digest")
 		_, err := c.AddComponentDependencies(&ociaccess.FindComponentVersionResult{
@@ -532,6 +554,25 @@ scheduler:
 			Version: "v0.0.1",
 			Type:    ResourceTypeHelmChart,
 			Value:   "registry.example.com:443/charts/my-chart:v0.0.1@sha256:deadbeef",
+		}))
+	})
+
+	It("should resolve relativeOciReference helmChart resources against the repository host with custom repository base", func() {
+		customRepoBase := "myrepo.example.com:1234/custom/path"
+		c = NewComponents(&configv1alpha1.OCMConfig{CustomRepositoryBase: new(customRepoBase)})
+		desc := buildRelativeOciDescriptor("example.com/comp-with-relative-helm-ref", "v0.0.1", ResourceTypeHelmChart, "my-chart", "v0.0.1", "charts/my-chart:v0.0.1@sha256:deadbeef")
+		_, err := c.AddComponentDependencies(&ociaccess.FindComponentVersionResult{
+			Descriptor:     desc,
+			RepositoryHost: "registry.example.com:443",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		ref := ComponentReferenceFromNameAndVersion(desc.Component.Name, desc.Component.Version)
+		Expect(c.GetResources(ref)).To(ConsistOf(Resource{
+			Name:    "my-chart",
+			Version: "v0.0.1",
+			Type:    ResourceTypeHelmChart,
+			Value:   customRepoBase + "/charts/my-chart:v0.0.1@sha256:deadbeef",
 		}))
 	})
 })
@@ -576,7 +617,8 @@ var _ = Describe("#resourceToImageSource", func() {
 				res.Name = "my-image"
 				res.Version = "1.2.3"
 
-				src, err := resourceToImageSource(res, repoHost)
+				c := NewComponents(nil)
+				src, err := c.resourceToImageSource(res, repoHost)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(src).NotTo(BeNil())
 				Expect(*src.Ref).To(Equal(expectedRef))

--- a/pkg/ocm/resolve.go
+++ b/pkg/ocm/resolve.go
@@ -58,7 +58,7 @@ func ResolveOCMComponents(log logr.Logger, cfg *configv1alpha1.LandscapeKitConfi
 		outputDir:    outputDir,
 		debug:        debug,
 		workers:      workers,
-		components:   components.NewComponents(),
+		components:   components.NewComponents(cfg.OCM),
 		repos:        repos,
 	}
 


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
Component descriptors using the `relativeOciReference` access type store only a registry-relative path. GLK must prepend a registry host to form a fully-qualified image reference. Previously this host was always auto-detected from the repository URL the descriptor was fetched from. This breaks when descriptors are mirrored to a registry whose URL differs from the original producer's host (e.g. a delivery mirror vs. the source registry).

This PR adds an optional `ocm.customRepositoryBase` field to the `LandscapeKitConfiguration`. When set, it replaces the auto-detected host for all `relativeOciReference` resolutions. Two integration tests cover the default (auto-detect) and override behaviour. Documentation updated accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add an optional `customRepositoryBase` field to `OCMConfig` for `relativeOciReference` resolution.
```
