### PR TITLE
Fix Renovate `generate` and missing `yq` dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ generate-ocm-testdata:
 	@go run $(HACK_DIR)/tools/ocm-testdata-generator -config $(REPO_ROOT)/pkg/ocm/components/testdata/config.yaml
 
 .PHONY: git-server-up
-git-server-up:
+git-server-up: $(YQ)
 	@bash $(REPO_ROOT)/dev-setup/git-server/git-server-up.sh
 
 .PHONY: git-server-down

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -12,9 +12,10 @@ FLUX_CLI ?= $(TOOLS_DIR)/bin/$(SYSTEM_NAME)-$(SYSTEM_ARCH)/flux
 flux-cli: $(FLUX_CLI)
 $(FLUX_CLI): $(TOOLS_DIR) $(call tool_version_file,$(FLUX_CLI),$(FLUX_CLI_VERSION))
 	@mkdir -p $(dir $(FLUX_CLI))
-	@# Prefer a lightweight docker wrapper, but fall back to downloading the flux CLI binary when docker is unavailable
-	@# (e.g. on the Renovate runner which has no docker daemon).
-	@if command -v docker >/dev/null 2>&1; then \
+	@# Prefer a lightweight docker wrapper, but fall back to downloading the flux CLI binary when docker is unavailable.
+	@# Note: the Renovate runner ships the docker binary but has no running daemon, so we probe for a reachable daemon
+	@# (docker info) instead of merely checking for the binary (command -v docker).
+	@if docker info >/dev/null 2>&1; then \
 		printf '#!/usr/bin/env bash\nset -e\ndocker run --rm -v "$(REPO_ROOT):$(REPO_ROOT)" ghcr.io/fluxcd/flux-cli:$(FLUX_CLI_VERSION) "$$@"\n' > $(FLUX_CLI); \
 		chmod +x $(FLUX_CLI); \
 	else \


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Renovate does have the `docker` cli executable in its path, but the daemon is not running. Changed the check to use `docker info` to assert running daemon.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
