### PR TITLE
Add support for pre- and post-generate commands in GitHub Action

### DIFF
--- a/.github/workflows/glk.yaml
+++ b/.github/workflows/glk.yaml
@@ -42,6 +42,11 @@ on:
         description: 'GLK version to use. Takes precedence over components-file when set.'
         required: false
         type: string
+      post-generate-commands:
+        description: 'Optional bash commands to run after GLK commands but before committing.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   glk:
@@ -72,6 +77,10 @@ jobs:
         image-tag: ${{ inputs.image-tag }}
         commands: ${{ inputs.glk-commands }}
         image-base: ${{ inputs.image-base }}
+
+    - name: Post-generate commands
+      if: ${{ inputs.post-generate-commands != '' }}
+      run: ${{ inputs.post-generate-commands }}
 
     - name: Commit and push changes
       id: push

--- a/.github/workflows/glk.yaml
+++ b/.github/workflows/glk.yaml
@@ -42,6 +42,11 @@ on:
         description: 'GLK version to use. Takes precedence over components-file when set.'
         required: false
         type: string
+      pre-generate-commands:
+        description: 'Optional bash commands to run before GLK commands but after checkout.'
+        required: false
+        type: string
+        default: ''
       post-generate-commands:
         description: 'Optional bash commands to run after GLK commands but before committing.'
         required: false
@@ -69,6 +74,10 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Pre-generate commands
+      if: ${{ inputs.pre-generate-commands != '' }}
+      run: ${{ inputs.pre-generate-commands }}
 
     - name: GLK Commands
       uses: ./.github/actions/glk


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Add option to pass `{pre,post}-generate-commands` to glk GHA workflow.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @MartinWeindel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add support for passing `{pre,post}-generate-commands` to glk GitHub Actions workflow to pass bash commands to run before or after the glk commands.
```
