### PR TITLE
 Add fork-mode in glk workflow to detect fork and only set status instead of pushing

### DIFF
--- a/.github/workflows/glk.yaml
+++ b/.github/workflows/glk.yaml
@@ -52,6 +52,14 @@ on:
         required: false
         type: string
         default: ''
+      fork-mode:
+        description: >
+          When true, the workflow runs in read-only fork mode: it generates but does not push.
+          If the generation produces a diff, the job fails with a descriptive message and posts
+          a failure status to the PR. If there is no diff, it posts a success status.
+        required: false
+        type: boolean
+        default: false
       oci-auth-username:
         description: 'OCI registry username for authentication (optional)'
         required: false
@@ -76,7 +84,7 @@ jobs:
       with:
         submodules: 'true'
         token: ${{ secrets.GITHUB_TOKEN }}
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
     - name: Set up Git
@@ -104,6 +112,7 @@ jobs:
       run: ${{ inputs.post-generate-commands }}
 
     - name: Commit and push changes
+      if: ${{ !inputs.fork-mode }}
       id: push
       run: |
         git add .
@@ -117,10 +126,49 @@ jobs:
         fi
 
     - name: Set status on pushed commit
-      if: ${{ inputs.set-commit-status && steps.push.outputs.pushed == 'true' }}
+      if: ${{ !inputs.fork-mode && inputs.set-commit-status && steps.push.outputs.pushed == 'true' }}
       run: |
-        curl -sfS -X POST \
+        curl -sS -X POST \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github+json" \
           "${{ github.api_url }}/repos/${{ github.repository }}/statuses/${{ steps.push.outputs.sha }}" \
-          -d "{\"state\":\"success\",\"context\":\"${{ inputs.status-context }}\",\"description\":\"GLK generation completed\"}"
+          -d "{\"state\":\"success\",\"context\":\"${{ inputs.status-context }}\",\"description\":\"GLK generation completed\"}" || true
+
+    - name: Check for diff (fork mode)
+      if: ${{ inputs.fork-mode }}
+      id: fork-diff
+      run: |
+        git add .
+        if git diff --cached --quiet; then
+          echo "has-diff=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "has-diff=true" >> "$GITHUB_OUTPUT"
+          echo "### GLK generation produced uncommitted changes" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          git diff --cached --stat >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: Post fork-mode status to PR
+      if: ${{ inputs.fork-mode && inputs.set-commit-status }}
+      run: |
+        if [[ "${{ steps.fork-diff.outputs.has-diff }}" == "true" ]]; then
+          state="failure"
+          description="GLK generation produced a diff. Open PR from the upstream repo (not a fork) or run 'glk generate base -c base/glk-config.yaml ./' manually."
+        else
+          state="success"
+          description="GLK generation produced no diff."
+        fi
+        curl -sS -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github+json" \
+          "${{ github.api_url }}/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+          -d "{\"state\":\"${state}\",\"context\":\"${{ inputs.status-context }}\",\"description\":\"${description}\"}" || true
+
+    - name: Fail if fork diff detected
+      if: ${{ inputs.fork-mode && steps.fork-diff.outputs.has-diff == 'true' }}
+      run: |
+        echo "GLK generation produced a diff that cannot be pushed to a fork."
+        echo "Please either open this PR from a branch in the upstream repository,"
+        echo "or run 'glk generate' locally and commit the results before opening the PR."
+        exit 1

--- a/.github/workflows/glk.yaml
+++ b/.github/workflows/glk.yaml
@@ -138,18 +138,17 @@ jobs:
       if: ${{ inputs.fork-mode }}
       id: fork-diff
       run: |
-        git add .
-        if git diff --cached --quiet; then
-          echo "has-diff=false" >> "$GITHUB_OUTPUT"
-        else
+        if git status --porcelain --untracked-files=normal | grep -q .; then
           echo "has-diff=true" >> "$GITHUB_OUTPUT"
           echo "### GLK generation produced uncommitted changes" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          git diff --cached --stat >> "$GITHUB_STEP_SUMMARY"
+          git status --short >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "has-diff=false" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Post fork-mode status to PR
+    - name: Post status to PR (fork-mode)
       if: ${{ inputs.fork-mode && inputs.set-commit-status }}
       run: |
         if [[ "${{ steps.fork-diff.outputs.has-diff }}" == "true" ]]; then
@@ -165,7 +164,7 @@ jobs:
           "${{ github.api_url }}/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
           -d "{\"state\":\"${state}\",\"context\":\"${{ inputs.status-context }}\",\"description\":\"${description}\"}" || true
 
-    - name: Fail if fork diff detected
+    - name: Fail if diff detected (fork mode)
       if: ${{ inputs.fork-mode && steps.fork-diff.outputs.has-diff == 'true' }}
       run: |
         echo "GLK generation produced a diff that cannot be pushed to a fork."


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
When run from forks, the GitHub Action does have no (out-of-the-box) access to the originating content and thus cannot push. In this case, the generation still runs, but if a diff is detected, the check fails and asks the user to run the generation manually.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
- [x] Based on top of https://github.com/gardener/gardener-landscape-kit/pull/466 to avoid merge conflicts.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Introduce `fork-mode` parameter to `glk` workflow to do a generation check without pushing for PRs from forked repositories.
```
