### PR TITLE
Add error message when config is not specified for glk generate command

### DIFF
--- a/pkg/cmd/generate/options/options.go
+++ b/pkg/cmd/generate/options/options.go
@@ -64,6 +64,10 @@ func (o *Options) Complete(args []string) error {
 	}
 	o.TargetDirPath = args[0]
 
+	if o.ConfigFilePath == "" {
+		return fmt.Errorf("config option is required, use -c/--config to specify the path to the configuration file")
+	}
+
 	data, err := os.ReadFile(o.ConfigFilePath) // #nosec G304 -- Trusted file from CLI argument.
 	if err != nil {
 		return fmt.Errorf("error reading config file: %w", err)


### PR DESCRIPTION
**How to categorize this PR?**
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Replaces cryptic message "Error: error reading config file: open : no such file or directory" when no config file is provided with command `glk generate`

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
```other operator
`glk generate base` and `glk generate landscape` now report a clear error when the required `-c`/`--config` flag is missing, instead of the confusing `open : no such file or directory` message.
```
