### PR TITLE
Use the same version for image and binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,8 @@ ifndef ARTIFACTS
 endif
 
 e2e-prepare: export BUILD_OUTPUT_FILE=$(TOOLS_BIN_DIR)
+e2e-prepare: export SOURCE_DIGEST=$(shell find $(shell yq '.build.artifacts[0].ko.dependencies.paths[]' $(REPO_ROOT)/dev-setup/skaffold.yaml | tr '\n' ' ') -type f | sort | xargs sha256sum | sha256sum | cut -c1-8)
+e2e-prepare: export LD_FLAGS=$(shell EFFECTIVE_VERSION=$(VERSION)-$(SOURCE_DIGEST) bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION $(NAME) $(BUILD_DATE))
 
 .PHONY: e2e-prepare
 e2e-prepare: build $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ) $(GLK_PRETTIFY)

--- a/dev-setup/git-repos/generate-repos.sh
+++ b/dev-setup/git-repos/generate-repos.sh
@@ -67,6 +67,9 @@ generate_base() {
 
   glk generate base -c "${GLK_CONFIG_PATH}" "${GLK_BASE_REPO_PATH}"
 
+  # Secrets configuration in the reusable workflow is not supported by Forgejo, see https://codeberg.org/forgejo/forgejo/issues/6069.
+  yq -i 'del(.on.workflow_call.secrets)' "${GLK_BASE_REPO_PATH}/.github/workflows/glk.yaml"
+
   cd "${GLK_BASE_REPO_PATH}"
   git add .
   git commit -m "Generate base" || echo "No changes to commit"
@@ -97,6 +100,10 @@ generate_landscape() {
   sed -i "s|<IMAGE-BASE>|$glk_dev_image_base|g" "$workflows_path/workflow-pr-post-change.yaml"
 
   cd "${GLK_LANDSCAPE_REPO_PATH}"
+
+  # Secrets configuration in the reusable workflow is not supported by Forgejo, see https://codeberg.org/forgejo/forgejo/issues/6069.
+  yq -i 'del(.on.workflow_call.secrets)' "${GLK_BASE_REPO_PATH}/.github/workflows/glk.yaml"
+
   git add .
   git commit -m "Generate test landscape" || echo "No changes to commit"
   git push

--- a/dev-setup/git-repos/landscapekitconfiguration.yaml
+++ b/dev-setup/git-repos/landscapekitconfiguration.yaml
@@ -20,6 +20,3 @@ components:
   include:
   - flux
   - github
-# TODO(timuthy): Remove this config once dev versions are ignored.
-versionConfig:
-  checkMode: Warning

--- a/dev-setup/skaffold.yaml
+++ b/dev-setup/skaffold.yaml
@@ -70,13 +70,11 @@ build:
               - "echo $SKAFFOLD_IMAGE > dev-setup/glk-dev-image"
   tagPolicy:
     customTemplate:
-      template: '{{.version}}-{{.sha}}-{{.digest}}'
+      template: '{{.version}}-{{.digest}}'
       components:
         - name: version
           envTemplate:
             template: '{{.VERSION}}'
-        - name: sha
-          gitCommit:
-            variant: AbbrevCommitSha
         - name: digest
-          inputDigest: {}
+          envTemplate:
+            template: '{{.SOURCE_DIGEST}}'


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Use the same dev version for the image build by Skaffold and the contained binary. This allows us to enable the version check again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
