### PR TITLE
Fix unsupported Forgejo workflow

### DIFF
--- a/dev-setup/git-repos/generate-repos.sh
+++ b/dev-setup/git-repos/generate-repos.sh
@@ -69,6 +69,7 @@ generate_base() {
 
   # Secrets configuration in the reusable workflow is not supported by Forgejo, see https://codeberg.org/forgejo/forgejo/issues/6069.
   yq -i 'del(.on.workflow_call.secrets)' "${GLK_BASE_REPO_PATH}/.github/workflows/glk.yaml"
+  yq -i 'del(.components.include[] | select(. == "github"))' "$GLK_CONFIG_PATH"
 
   cd "${GLK_BASE_REPO_PATH}"
   git add .
@@ -83,6 +84,7 @@ checkout_landscape_repo() {
 
 generate_landscape() {
   echo "🌱 Generating test landscape"
+  yq -i '.components.include += ["github"]' "$GLK_CONFIG_PATH"
   glk generate landscape -c "${GLK_CONFIG_PATH}" "${GLK_LANDSCAPE_REPO_PATH}"
 
   local glk_dev_image=$(cat $SCRIPT_DIR/../glk-dev-image)
@@ -102,7 +104,8 @@ generate_landscape() {
   cd "${GLK_LANDSCAPE_REPO_PATH}"
 
   # Secrets configuration in the reusable workflow is not supported by Forgejo, see https://codeberg.org/forgejo/forgejo/issues/6069.
-  yq -i 'del(.on.workflow_call.secrets)' "${GLK_BASE_REPO_PATH}/.github/workflows/glk.yaml"
+  yq -i 'del(.on.workflow_call.secrets)' "${GLK_LANDSCAPE_REPO_PATH}/.github/workflows/glk.yaml"
+  yq -i 'del(.components.include[] | select(. == "github"))' "$GLK_CONFIG_PATH"
 
   git add .
   git commit -m "Generate test landscape" || echo "No changes to commit"

--- a/test/e2e/create.go
+++ b/test/e2e/create.go
@@ -55,6 +55,8 @@ var _ = Describe("Create Gardener Landscape", Label("Garden", "default"), Ordere
 		Expect(config.Components).NotTo(BeNil())
 		// activate all components
 		config.Components.Include = nil
+		// deactivate the github component to retain changes
+		config.Components.Exclude = []string{"github"}
 
 		configBytes, err = yaml.Marshal(config)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Fixes failing e2e tests because `.on.workflow_call.secrets` is not supported by Forgejo.

<img width="1721" height="344" alt="image" src="https://github.com/user-attachments/assets/f3dcad29-17a1-434a-8379-62d4e58f4769" />

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up for https://github.com/gardener/gardener-landscape-kit/pull/490/changes/32003c5b145815cf3004afe13452b6635277aa19.

Regressed with #470

We might want to consider enabling the usual diff control for the `github` component and revert this band-aid again.
/cc @MartinWeindel @LucaBernstein

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
