### PR TITLE
Trigger source reconciliation in e2e tests (speedup)

### DIFF
--- a/test/e2e/create.go
+++ b/test/e2e/create.go
@@ -292,10 +292,7 @@ data: {}
 		case v1alpha1.KindOCIRepository:
 			src := &sourcev1.OCIRepository{}
 			Expect(runtimeClusterClient.Client().Get(ctx, sourceKey, src)).To(Succeed())
-			if src.Annotations == nil {
-				src.Annotations = make(map[string]string)
-			}
-			src.Annotations[fluxmeta.ReconcileRequestAnnotation] = requestedAt
+			metav1.SetMetaDataAnnotation(&src.ObjectMeta, fluxmeta.ReconcileRequestAnnotation, requestedAt)
 			Expect(runtimeClusterClient.Client().Update(ctx, src)).To(Succeed())
 
 			By("Waiting for OCIRepository to acknowledge reconciliation")
@@ -306,10 +303,7 @@ data: {}
 		default:
 			src := &sourcev1.GitRepository{}
 			Expect(runtimeClusterClient.Client().Get(ctx, sourceKey, src)).To(Succeed())
-			if src.Annotations == nil {
-				src.Annotations = make(map[string]string)
-			}
-			src.Annotations[fluxmeta.ReconcileRequestAnnotation] = requestedAt
+			metav1.SetMetaDataAnnotation(&src.ObjectMeta, fluxmeta.ReconcileRequestAnnotation, requestedAt)
 			Expect(runtimeClusterClient.Client().Update(ctx, src)).To(Succeed())
 
 			By("Waiting for GitRepository to acknowledge reconciliation")

--- a/test/e2e/create.go
+++ b/test/e2e/create.go
@@ -15,6 +15,7 @@ import (
 
 	fluxv1 "github.com/fluxcd/kustomize-controller/api/v1"
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -255,6 +256,7 @@ data: {}
 	It("Create Kubernetes client", func() {
 		runtimeScheme := runtime.NewScheme()
 		Expect(fluxv1.AddToScheme(runtimeScheme)).To(Succeed())
+		Expect(sourcev1.AddToScheme(runtimeScheme)).To(Succeed())
 		Expect(operatorclient.AddRuntimeSchemeToScheme(runtimeScheme)).To(Succeed())
 
 		var err error
@@ -270,6 +272,53 @@ data: {}
 		s = &GardenContext{}
 		s.WithVirtualClusterClientSet(runtimeClusterClient)
 	})
+
+	It("Reconcile Source", func(ctx SpecContext) {
+		config := &v1alpha1.LandscapeKitConfiguration{}
+		configBytes, err := os.ReadFile(ConfigPath) // #nosec G304 -- controlled by test.
+		Expect(err).NotTo(HaveOccurred())
+		Expect(yaml.Unmarshal(configBytes, config)).To(Succeed())
+
+		sourceKey := client.ObjectKey{Name: "flux-system", Namespace: "flux-system"}
+		requestedAt := time.Now().Format(time.RFC3339Nano)
+
+		sourceKind := v1alpha1.KindGitRepository
+		if config.Repositories != nil && config.Repositories.Landscape != nil && config.Repositories.Landscape.Kind != "" {
+			sourceKind = config.Repositories.Landscape.Kind
+		}
+
+		By("Annotating source to trigger reconciliation")
+		switch sourceKind {
+		case v1alpha1.KindOCIRepository:
+			src := &sourcev1.OCIRepository{}
+			Expect(runtimeClusterClient.Client().Get(ctx, sourceKey, src)).To(Succeed())
+			if src.Annotations == nil {
+				src.Annotations = make(map[string]string)
+			}
+			src.Annotations[fluxmeta.ReconcileRequestAnnotation] = requestedAt
+			Expect(runtimeClusterClient.Client().Update(ctx, src)).To(Succeed())
+
+			By("Waiting for OCIRepository to acknowledge reconciliation")
+			Eventually(ctx, func(g Gomega) {
+				g.Expect(runtimeClusterClient.Client().Get(ctx, sourceKey, src)).To(Succeed())
+				g.Expect(src.Status.GetLastHandledReconcileRequest()).To(Equal(requestedAt))
+			}).Should(Succeed())
+		default:
+			src := &sourcev1.GitRepository{}
+			Expect(runtimeClusterClient.Client().Get(ctx, sourceKey, src)).To(Succeed())
+			if src.Annotations == nil {
+				src.Annotations = make(map[string]string)
+			}
+			src.Annotations[fluxmeta.ReconcileRequestAnnotation] = requestedAt
+			Expect(runtimeClusterClient.Client().Update(ctx, src)).To(Succeed())
+
+			By("Waiting for GitRepository to acknowledge reconciliation")
+			Eventually(ctx, func(g Gomega) {
+				g.Expect(runtimeClusterClient.Client().Get(ctx, sourceKey, src)).To(Succeed())
+				g.Expect(src.Status.GetLastHandledReconcileRequest()).To(Equal(requestedAt))
+			}).Should(Succeed())
+		}
+	}, SpecTimeout(5*time.Minute))
 
 	It("Reconcile Garden", func(ctx SpecContext) {
 		garden := &operatorv1alpha1.Garden{ObjectMeta: metav1.ObjectMeta{Name: "garden"}}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Speeds-up e2e tests by cutting the waiting time for the next sync interval occurrence short.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
