### PR TITLE
Revert "Update go to 1.27 (main)"

### DIFF
--- a/.github/actions/prepare-release/action.yaml
+++ b/.github/actions/prepare-release/action.yaml
@@ -5,7 +5,7 @@ runs:
   steps:
   - uses: actions/setup-go@v7
     with:
-      go-version: '1.27'
+      go-version: '1.26'
   - name: prepare-release
     shell: bash
     run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.27'
+          go-version: '1.26'
       - name: run-verify
         shell: bash
         run: |
@@ -127,7 +127,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.27'
+          go-version: '1.26'
       - name: import-release-commit
         if: ${{ inputs.commit-objects-artefact != '' }}
         uses: gardener/cc-utils/.github/actions/import-commit@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder
-FROM --platform=$BUILDPLATFORM golang:1.27.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7 AS builder
 
 ARG EFFECTIVE_VERSION
 ARG BUILD_DATE


### PR DESCRIPTION
Reverts gardener/gardener-landscape-kit#509

Due to issues in the repo HEAD builds: golangci-lint does not work there: https://github.com/gardener/gardener-landscape-kit/actions/runs/32725066701/job/97424382640

/cc @timuthy 
/area delivery
/kind bug