### PR TITLE
Pin `GOTOOLCHAIN` version and mirror forgejo runner image to local registry

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,18 @@ The following dependencies have been updated:\n\
       datasourceTemplate: 'docker',
     },
   ],
+  customManagers: [
+    {
+      // Detection for GOTOOLCHAIN in Makefile (does not match the _VERSION pattern of the ci-infra preset).
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^Makefile$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)\\s+export GOTOOLCHAIN\\s*\\??=\\s*go(?<currentValue>[^\\s]+)',
+      ],
+    },
+  ],
   packageRules: [
     {
       groupName: 'gardener/gardener',

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ export LD_FLAGS              = $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-fl
 export SKAFFOLD_DEFAULT_REPO = glk-registry.local.gardener.cloud:6001
 export SKAFFOLD_PUSH         = true
 
+# Use a specific Go toolchain version to ensure consistent builds across different environments.
+# renovate: datasource=golang-version depName=go
+export GOTOOLCHAIN := go1.26.7
+
 #########################################
 # Tools                                 #
 #########################################

--- a/dev-setup/env.sh
+++ b/dev-setup/env.sh
@@ -20,6 +20,8 @@ export GIT_SERVER_URL="http://git.local.gardener.cloud:6080"
 
 # Registry
 export REGISTRY_HOSTNAME="glk-registry.local.gardener.cloud"
+export RUNNER_JOB_IMAGE_SOURCE="codeberg.org/oranki/forgejo-runner:3.5.1"
+export RUNNER_JOB_IMAGE_LOCAL="${REGISTRY_HOSTNAME}:6001/forgejo-runner-job:3.5.1"
 
 # Kind Cluster
 export GLK_KIND_CLUSTER_PREFIX=${GLK_KIND_CLUSTER_PREFIX-glk}

--- a/dev-setup/git-server/git-server-up.sh
+++ b/dev-setup/git-server/git-server-up.sh
@@ -88,6 +88,11 @@ done
 
 echo "🚀 git-server is up and running at $GIT_SERVER_URL"
 
+echo "📦 Mirroring runner job container image to local registry"
+docker pull "$RUNNER_JOB_IMAGE_SOURCE"
+docker tag "$RUNNER_JOB_IMAGE_SOURCE" "$RUNNER_JOB_IMAGE_LOCAL"
+docker push "$RUNNER_JOB_IMAGE_LOCAL"
+
 for repo_name in $GLK_BASE_REPO_NAME $GLK_LANDSCAPE_REPO_NAME; do
   create_repo $repo_name
 done

--- a/dev-setup/git-server/runner-config.yaml
+++ b/dev-setup/git-server/runner-config.yaml
@@ -63,7 +63,7 @@ runner:
   # Like: ["macos-arm64:host", "ubuntu-latest:docker://node:20-bookworm", "ubuntu-22.04:docker://node:20-bookworm"]
   # If it's empty when registering, it will ask for inputting labels.
   # If it's empty when executing the `daemon`, it will use labels in the `.runner` file.
-  labels: ["d","docker:docker://codeberg.org/oranki/forgejo-runner:3.5.1"]
+  labels: ["d","docker:docker://glk-registry.local.gardener.cloud:6001/forgejo-runner-job:3.5.1"]
 
 cache:
   #


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
- Detect Go version incompatibilities early in Prow checks: https://github.com/gardener/gardener-landscape-kit/pull/514
- Since 2 days the forgejo action is not able to pull the runner image anymore: https://prow.gardener.cloud/job-history/gs/gardener-prow/pr-logs/directory/pull-gardener-landscape-kit-e2e-kind?buildId=
  - https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener-landscape-kit/515/pull-gardener-landscape-kit-e2e-kind/2092610143618338816/artifacts/forgejo-runner.log

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Use pinned `GOTOOLCHAIN` version (Go 1.26.7) and copy forgejo-runner image to local registry.
```
